### PR TITLE
feat: env var auto-mapping + shell completion (PR2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,37 @@ $ mytool pish
 quicli error: unknown subcommand 'pish', did you mean 'push'?
 ```
 
+### Env vars
+
+Every flag automatically reads from an env var as fallback before using the default.
+Auto-derived name: `PROGNAME_FLAGNAME` (uppercase, non-alphanumeric → `_`).
+
+```bash
+SAY_HELLO_COUNT=5 ./say-hello   # same as --count 5
+```
+
+Override the env var name per flag:
+```golang
+{Name: "token", Default: "", Description: "API token", EnvVar: "MY_API_TOKEN"}
+```
+
+Opt a flag out of env var lookup:
+```golang
+{Name: "secret", Default: "", Description: "...", EnvVar: "-"}
+```
+
+The env var name is shown in help output: `(default: 0) [env: SAY_HELLO_COUNT]`
+
+### Shell completion
+
+Every CLI built with quicli gets `--completion <shell>` for free:
+
+```bash
+./mycli --completion bash >> ~/.bash_completion
+./mycli --completion zsh  > ~/.zsh/completions/_mycli
+./mycli --completion fish > ~/.config/fish/completions/mycli.fish
+```
+
 Get more  [examples](examples/)
 
 ### Disclaimer

--- a/pkg/quicli/completion.go
+++ b/pkg/quicli/completion.go
@@ -1,0 +1,153 @@
+package quicli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// generateCompletion returns a shell completion script for the given Cli and shell.
+func generateCompletion(c *Cli, shell string) (string, error) {
+	switch shell {
+	case "bash":
+		return generateBashCompletion(c), nil
+	case "zsh":
+		return generateZshCompletion(c), nil
+	case "fish":
+		return generateFishCompletion(c), nil
+	default:
+		return "", fmt.Errorf("unsupported shell %q — use bash, zsh, or fish", shell)
+	}
+}
+
+func cliProgName() string {
+	return filepath.Base(os.Args[0])
+}
+
+// allSubcommandNames returns all subcommand names and aliases as a flat slice.
+func allSubcommandNames(subs Subcommands) []string {
+	var names []string
+	for _, s := range subs {
+		names = append(names, s.Name)
+		if s.Aliases != nil {
+			names = append(names, s.Aliases.ToSlice()...)
+		}
+	}
+	return names
+}
+
+// allFlagNames returns --long and -short flag names for the given flags.
+func allFlagNames(flags []Flag) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, f := range flags {
+		names = append(names, "--"+f.Name)
+		short := f.ShortName
+		if short == "" {
+			short = f.Name[0:1]
+		}
+		if !f.NoShortName && !seen[short] {
+			names = append(names, "-"+short)
+			seen[short] = true
+		}
+	}
+	return names
+}
+
+func generateBashCompletion(c *Cli) string {
+	prog := cliProgName()
+	fnName := "_" + strings.ReplaceAll(prog, "-", "_") + "_completion"
+	cmds := strings.Join(allSubcommandNames(c.Subcommands), " ")
+	flags := strings.Join(allFlagNames(c.Flags), " ")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s() {\n", fnName)
+	fmt.Fprintf(&b, "    local cur=\"${COMP_WORDS[COMP_CWORD]}\"\n")
+	if len(c.Subcommands) > 0 {
+		fmt.Fprintf(&b, "    local commands=\"%s\"\n", cmds)
+	}
+	fmt.Fprintf(&b, "    local flags=\"%s\"\n", flags)
+	fmt.Fprintf(&b, "\n")
+	if len(c.Subcommands) > 0 {
+		fmt.Fprintf(&b, "    if [[ $COMP_CWORD -eq 1 ]]; then\n")
+		fmt.Fprintf(&b, "        COMPREPLY=( $(compgen -W \"$commands $flags\" -- \"$cur\") )\n")
+		fmt.Fprintf(&b, "    else\n")
+		fmt.Fprintf(&b, "        COMPREPLY=( $(compgen -W \"$flags\" -- \"$cur\") )\n")
+		fmt.Fprintf(&b, "    fi\n")
+	} else {
+		fmt.Fprintf(&b, "    COMPREPLY=( $(compgen -W \"$flags\" -- \"$cur\") )\n")
+	}
+	fmt.Fprintf(&b, "}\n")
+	fmt.Fprintf(&b, "complete -F %s %s\n", fnName, prog)
+	return b.String()
+}
+
+func generateZshCompletion(c *Cli) string {
+	prog := cliProgName()
+	fnName := "_" + strings.ReplaceAll(prog, "-", "_")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "#compdef %s\n", prog)
+	fmt.Fprintf(&b, "%s() {\n", fnName)
+
+	if len(c.Subcommands) > 0 {
+		fmt.Fprintf(&b, "    local -a commands\n")
+		fmt.Fprintf(&b, "    commands=(\n")
+		for _, s := range c.Subcommands {
+			fmt.Fprintf(&b, "        '%s:%s'\n", s.Name, s.Description)
+		}
+		fmt.Fprintf(&b, "    )\n")
+		fmt.Fprintf(&b, "    local -a flags\n")
+		fmt.Fprintf(&b, "    flags=(\n")
+		for _, f := range c.Flags {
+			fmt.Fprintf(&b, "        '--%s[%s]'\n", f.Name, f.Description)
+		}
+		fmt.Fprintf(&b, "    )\n")
+		fmt.Fprintf(&b, "    if (( CURRENT == 2 )); then\n")
+		fmt.Fprintf(&b, "        _describe 'commands' commands\n")
+		fmt.Fprintf(&b, "    else\n")
+		fmt.Fprintf(&b, "        _arguments $flags\n")
+		fmt.Fprintf(&b, "    fi\n")
+	} else {
+		fmt.Fprintf(&b, "    local -a flags\n")
+		fmt.Fprintf(&b, "    flags=(\n")
+		for _, f := range c.Flags {
+			fmt.Fprintf(&b, "        '--%s[%s]'\n", f.Name, f.Description)
+		}
+		fmt.Fprintf(&b, "    )\n")
+		fmt.Fprintf(&b, "    _arguments $flags\n")
+	}
+
+	fmt.Fprintf(&b, "}\n")
+	fmt.Fprintf(&b, "%s \"$@\"\n", fnName)
+	return b.String()
+}
+
+func generateFishCompletion(c *Cli) string {
+	prog := cliProgName()
+	var b strings.Builder
+
+	for _, s := range c.Subcommands {
+		fmt.Fprintf(&b, "complete -c %s -n \"__fish_use_subcommand\" -f -a %s -d '%s'\n",
+			prog, s.Name, s.Description)
+		if s.Aliases != nil {
+			for _, alias := range s.Aliases.ToSlice() {
+				fmt.Fprintf(&b, "complete -c %s -n \"__fish_use_subcommand\" -f -a %s -d '%s (alias)'\n",
+					prog, alias, s.Description)
+			}
+		}
+	}
+	for _, f := range c.Flags {
+		short := f.ShortName
+		if short == "" {
+			short = f.Name[0:1]
+		}
+		if f.NoShortName {
+			fmt.Fprintf(&b, "complete -c %s -l %s -d '%s'\n", prog, f.Name, f.Description)
+		} else {
+			fmt.Fprintf(&b, "complete -c %s -s %s -l %s -d '%s'\n", prog, short, f.Name, f.Description)
+		}
+	}
+	return b.String()
+}

--- a/pkg/quicli/completion_test.go
+++ b/pkg/quicli/completion_test.go
@@ -1,0 +1,75 @@
+package quicli
+
+import (
+	"strings"
+	"testing"
+)
+
+func testCli() Cli {
+	return Cli{
+		Usage:       "prog [command] [flags]",
+		Description: "test cli",
+		Flags: Flags{
+			{Name: "verbose", Default: false, Description: "verbose output"},
+			{Name: "output", Default: "text", Description: "output format"},
+		},
+		Subcommands: Subcommands{
+			{Name: "build", Aliases: Aliases("b"), Description: "build the project", Function: func(Config) {}},
+			{Name: "test", Description: "run tests", Function: func(Config) {}},
+		},
+		Function: func(Config) {},
+	}
+}
+
+func TestGenerateBashCompletion(t *testing.T) {
+	cli := testCli()
+	script, err := generateCompletion(&cli, "bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "build") {
+		t.Error("bash completion missing subcommand 'build'")
+	}
+	if !strings.Contains(script, "--verbose") {
+		t.Error("bash completion missing flag '--verbose'")
+	}
+	if !strings.Contains(script, "complete -F") {
+		t.Error("bash completion missing complete builtin")
+	}
+}
+
+func TestGenerateZshCompletion(t *testing.T) {
+	cli := testCli()
+	script, err := generateCompletion(&cli, "zsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "#compdef") {
+		t.Error("zsh completion missing #compdef header")
+	}
+	if !strings.Contains(script, "build") {
+		t.Error("zsh completion missing subcommand 'build'")
+	}
+}
+
+func TestGenerateFishCompletion(t *testing.T) {
+	cli := testCli()
+	script, err := generateCompletion(&cli, "fish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "complete -c") {
+		t.Error("fish completion missing 'complete -c'")
+	}
+	if !strings.Contains(script, "build") {
+		t.Error("fish completion missing subcommand 'build'")
+	}
+}
+
+func TestGenerateCompletionUnknownShell(t *testing.T) {
+	cli := testCli()
+	_, err := generateCompletion(&cli, "powershell")
+	if err == nil {
+		t.Error("expected error for unknown shell")
+	}
+}

--- a/pkg/quicli/envvar.go
+++ b/pkg/quicli/envvar.go
@@ -1,0 +1,60 @@
+package quicli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// envVarName derives the auto env var name from program name and flag name.
+// Example: progName="say-hello", flagName="count" → "SAY_HELLO_COUNT"
+func envVarName(progName, flagName string) string {
+	base := filepath.Base(progName)
+	sanitize := func(s string) string {
+		var b strings.Builder
+		for _, r := range strings.ToUpper(s) {
+			if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+				b.WriteRune(r)
+			} else {
+				b.WriteRune('_')
+			}
+		}
+		return b.String()
+	}
+	return sanitize(base) + "_" + sanitize(flagName)
+}
+
+// applyEnvVars reads env vars for flags not explicitly provided on the CLI
+// and updates config accordingly. Priority: CLI flag > env var > default.
+func applyEnvVars(flags []Flag, fs *flag.FlagSet) {
+	// Collect flags explicitly set on the command line.
+	cliProvided := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		cliProvided[f.Name] = true
+	})
+
+	for _, f := range flags {
+		if cliProvided[f.Name] {
+			continue
+		}
+		// Determine the env var key to check.
+		envKey := f.EnvVar
+		if envKey == "-" {
+			continue // opted out
+		}
+		if envKey == "" {
+			envKey = envVarName(os.Args[0], f.Name)
+		}
+		val, ok := os.LookupEnv(envKey)
+		if !ok {
+			continue
+		}
+		// Apply via fs.Set so the flag package parses and stores it correctly.
+		if err := fs.Set(f.Name, val); err != nil {
+			fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for flag --%s: %v\n", envKey, val, f.Name, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/pkg/quicli/envvar_test.go
+++ b/pkg/quicli/envvar_test.go
@@ -1,0 +1,87 @@
+package quicli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvVarName(t *testing.T) {
+	cases := []struct {
+		progName string
+		flagName string
+		want     string
+	}{
+		{"say-hello", "count", "SAY_HELLO_COUNT"},
+		{"./mycli", "output-format", "MYCLI_OUTPUT_FORMAT"},
+		{"prog", "file", "PROG_FILE"},
+	}
+	for _, tc := range cases {
+		if got := envVarName(tc.progName, tc.flagName); got != tc.want {
+			t.Errorf("envVarName(%q, %q) = %q, want %q", tc.progName, tc.flagName, got, tc.want)
+		}
+	}
+}
+
+func TestApplyEnvVarInt(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	os.Setenv("PROG_COUNT", "7")
+	defer os.Unsetenv("PROG_COUNT")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "count", Default: 0, Description: "count"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetIntFlag("count"); got != 7 {
+		t.Errorf("env var int: got %d, want 7", got)
+	}
+}
+
+func TestApplyEnvVarExplicit(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	os.Setenv("MY_CUSTOM_COUNT", "99")
+	defer os.Unsetenv("MY_CUSTOM_COUNT")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "count", Default: 0, Description: "count", EnvVar: "MY_CUSTOM_COUNT"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetIntFlag("count"); got != 99 {
+		t.Errorf("explicit EnvVar: got %d, want 99", got)
+	}
+}
+
+func TestApplyEnvVarOptOut(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	os.Setenv("PROG_SECRET", "ignored")
+	defer os.Unsetenv("PROG_SECRET")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "secret", Default: "default", Description: "secret", EnvVar: "-"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetStringFlag("secret"); got != "default" {
+		t.Errorf("opt-out: got %q, want default", got)
+	}
+}
+
+func TestApplyEnvVarCLIOverridesEnv(t *testing.T) {
+	defer setArgs([]string{"prog", "--count", "3"})()
+	os.Setenv("PROG_COUNT", "99")
+	defer os.Unsetenv("PROG_COUNT")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "count", Default: 0, Description: "count"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetIntFlag("count"); got != 3 {
+		t.Errorf("CLI should override env var: got %d, want 3", got)
+	}
+}

--- a/pkg/quicli/flag_helpers.go
+++ b/pkg/quicli/flag_helpers.go
@@ -11,21 +11,33 @@ import (
 	stringSlice "github.com/ariary/go-utils/pkg/stringSlice"
 )
 
+// flagEnvVarDisplay returns the env var name to show in help, or "" to suppress.
+func flagEnvVarDisplay(f Flag) string {
+	if f.EnvVar == "-" {
+		return ""
+	}
+	if f.EnvVar != "" {
+		return f.EnvVar
+	}
+	return envVarName(os.Args[0], f.Name)
+}
+
 func createIntFlag(cfg Config, f Flag, shorts *[]string, wUsage *tabwriter.Writer, fs *flag.FlagSet) {
 	name := f.Name
 	shortName := f.ShortName
 	if shortName == "" {
 		shortName = name[0:1]
 	}
+	ev := flagEnvVarDisplay(f)
 	var intPtr int
 	fs.IntVar(&intPtr, name, int(reflect.ValueOf(f.Default).Int()), f.Description)
 	if !stringSlice.Contains(*shorts, shortName) && !f.NoShortName {
 		fs.IntVar(&intPtr, shortName, int(reflect.ValueOf(f.Default).Int()), f.Description)
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName, ev))
 		cfg.Flags[shortName] = &intPtr
 		*shorts = append(*shorts, shortName)
 	} else {
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, ""))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, "", ev))
 	}
 	cfg.Flags[name] = &intPtr
 }
@@ -36,15 +48,16 @@ func createStringFlag(cfg Config, f Flag, shorts *[]string, wUsage *tabwriter.Wr
 	if shortName == "" {
 		shortName = name[0:1]
 	}
+	ev := flagEnvVarDisplay(f)
 	var strPtr string
 	fs.StringVar(&strPtr, name, reflect.ValueOf(f.Default).String(), f.Description)
 	if !stringSlice.Contains(*shorts, shortName) && !f.NoShortName {
 		fs.StringVar(&strPtr, shortName, reflect.ValueOf(f.Default).String(), f.Description)
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName, ev))
 		cfg.Flags[shortName] = &strPtr
 		*shorts = append(*shorts, shortName)
 	} else {
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, ""))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, "", ev))
 	}
 	cfg.Flags[name] = &strPtr
 }
@@ -55,16 +68,17 @@ func createBoolFlag(cfg Config, f Flag, shorts *[]string, wUsage *tabwriter.Writ
 	if shortName == "" {
 		shortName = name[0:1]
 	}
+	ev := flagEnvVarDisplay(f)
 	var bPtr bool
 	fs.BoolVar(&bPtr, name, reflect.ValueOf(f.Default).Bool(), f.Description)
 	cfg.Flags[name] = &bPtr
 	if !stringSlice.Contains(*shorts, shortName) && !f.NoShortName {
 		fs.BoolVar(&bPtr, shortName, reflect.ValueOf(f.Default).Bool(), f.Description)
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName, ev))
 		cfg.Flags[shortName] = &bPtr
 		*shorts = append(*shorts, shortName)
 	} else {
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, ""))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, "", ev))
 	}
 	cfg.Flags[name] = &bPtr
 }
@@ -75,16 +89,17 @@ func createFloatFlag(cfg Config, f Flag, shorts *[]string, wUsage *tabwriter.Wri
 	if shortName == "" {
 		shortName = name[0:1]
 	}
+	ev := flagEnvVarDisplay(f)
 	var floatPtr float64
 	fs.Float64Var(&floatPtr, name, reflect.ValueOf(f.Default).Float(), f.Description)
 	cfg.Flags[name] = &floatPtr
 	if !stringSlice.Contains(*shorts, shortName) && !f.NoShortName {
 		fs.Float64Var(&floatPtr, shortName, reflect.ValueOf(f.Default).Float(), f.Description)
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName, ev))
 		cfg.Flags[shortName] = &floatPtr
 		*shorts = append(*shorts, shortName)
 	} else {
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, ""))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, "", ev))
 	}
 	cfg.Flags[name] = &floatPtr
 }
@@ -95,38 +110,45 @@ func createStringSliceFlag(cfg Config, f Flag, shorts *[]string, wUsage *tabwrit
 	if shortName == "" {
 		shortName = name[0:1]
 	}
+	ev := flagEnvVarDisplay(f)
 	val := []string{}
 	sv := &stringSliceValue{val: &val}
 	fs.Var(sv, name, f.Description)
 	if !stringSlice.Contains(*shorts, shortName) && !f.NoShortName {
 		fs.Var(sv, shortName, f.Description)
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, shortName, ev))
 		cfg.Flags[shortName] = sv
 		*shorts = append(*shorts, shortName)
 	} else {
-		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, ""))
+		fmt.Fprintf(wUsage, getFlagLine(f.Description, f.Default, name, "", ev))
 	}
 	cfg.Flags[name] = sv
 }
 
 // getFlagLine returns the help line for a flag.
-func getFlagLine(description string, defaultValue any, long string, short string) string {
+func getFlagLine(description string, defaultValue any, long string, short string, envVar string) string {
 	defaultStr := ". (default: "
 	switch v := defaultValue.(type) {
 	case int:
-		defaultStr += strconv.Itoa(v) + ")\n"
+		defaultStr += strconv.Itoa(v)
 	case string:
-		defaultStr += `"` + v + `")` + "\n"
+		defaultStr += `"` + v + `"`
 	case bool:
-		defaultStr += strconv.FormatBool(v) + ")\n"
+		defaultStr += strconv.FormatBool(v)
 	case float64:
-		defaultStr += strconv.FormatFloat(v, 'f', -1, 64) + ")\n"
+		defaultStr += strconv.FormatFloat(v, 'f', -1, 64)
 	case []string:
-		defaultStr += "[])\n"
+		defaultStr += "[]"
 	default:
 		fmt.Println(QUICLI_ERROR_PREFIX+"Unknown type for default value:", defaultValue)
 		os.Exit(2)
 	}
+	defaultStr += ")"
+	if envVar != "" {
+		defaultStr += " [env: " + envVar + "]"
+	}
+	defaultStr += "\n"
+
 	if short == "" {
 		return "--" + long + "\t\t\t" + description + defaultStr
 	}

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -158,6 +158,7 @@ func (c *Cli) Parse() (config Config) {
 	fs.Usage = func() { fmt.Print(usage.String()) }
 	fs.Parse(os.Args[1:])
 	config.Args = fs.Args()
+	applyEnvVars(c.Flags, fs)
 
 	if len(c.CheatSheet) > 0 && cheatSheet {
 		c.PrintCheatSheet()

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -154,11 +154,24 @@ func (c *Cli) Parse() (config Config) {
 		fs.BoolVar(&cheatSheet, "cs", false, "print cheat sheet")
 	}
 
+	var completionShell string
+	fs.StringVar(&completionShell, "completion", "", "generate shell completion script (bash, zsh, fish)")
+
 	wUsage.Flush()
 	fs.Usage = func() { fmt.Print(usage.String()) }
 	fs.Parse(os.Args[1:])
 	config.Args = fs.Args()
 	applyEnvVars(c.Flags, fs)
+
+	if completionShell != "" {
+		script, err := generateCompletion(c, completionShell)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, QUICLI_ERROR_PREFIX+err.Error())
+			os.Exit(1)
+		}
+		fmt.Print(script)
+		os.Exit(0)
+	}
 
 	if len(c.CheatSheet) > 0 && cheatSheet {
 		c.PrintCheatSheet()

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -188,6 +188,12 @@ func (c *Cli) RunWithSubcommand() {
 		fs.Parse(os.Args[2:])
 	}
 	config.Args = fs.Args()
+	allFlags := c.Flags
+	if !isRootCommand(c.Subcommands) {
+		sub := getSubcommandByName(c.Subcommands, os.Args[1])
+		allFlags = append(allFlags, sub.Flags...)
+	}
+	applyEnvVars(allFlags, fs)
 
 	//cheat sheet pt2
 	if len(c.CheatSheet) > 0 && cheatSheet {

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -175,9 +175,12 @@ func (c *Cli) RunWithSubcommand() {
 	var cheatSheet bool
 	if len(c.CheatSheet) > 0 {
 		fmt.Fprintf(wUsage, "\nSee command examples with \""+os.Args[0]+" --cheat-sheet\"\n")
-		flag.BoolVar(&cheatSheet, "cheat-sheet", false, "print cheat sheet")
-		flag.BoolVar(&cheatSheet, "cs", false, "print cheat sheet")
+		fs.BoolVar(&cheatSheet, "cheat-sheet", false, "print cheat sheet")
+		fs.BoolVar(&cheatSheet, "cs", false, "print cheat sheet")
 	}
+
+	var completionShell string
+	fs.StringVar(&completionShell, "completion", "", "generate shell completion script (bash, zsh, fish)")
 
 	wUsage.Flush()
 	// Parse
@@ -194,6 +197,16 @@ func (c *Cli) RunWithSubcommand() {
 		allFlags = append(allFlags, sub.Flags...)
 	}
 	applyEnvVars(allFlags, fs)
+
+	if completionShell != "" {
+		script, err := generateCompletion(c, completionShell)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, QUICLI_ERROR_PREFIX+err.Error())
+			os.Exit(1)
+		}
+		fmt.Print(script)
+		os.Exit(0)
+	}
 
 	//cheat sheet pt2
 	if len(c.CheatSheet) > 0 && cheatSheet {


### PR DESCRIPTION
## Summary

- Auto-map every flag to `PROGNAME_FLAGNAME` env var; shown in help as `[env: SAY_HELLO_COUNT]`
- Per-flag `EnvVar` override (`EnvVar: "CUSTOM_NAME"`) and opt-out (`EnvVar: "-"`)
- CLI flag always wins over env var; env var wins over default
- Auto-injected `--completion <shell>` flag generates bash/zsh/fish scripts from the live `Cli` struct
- No new dependencies — pure stdlib

**Depends on:** #8 (PR1)

## Test plan

- [ ] `go test ./pkg/quicli/... -v` — 16 tests, all pass
- [ ] `TestEnvVarName` — derivation logic
- [ ] `TestApplyEnvVarInt/Explicit/OptOut/CLIOverridesEnv` — priority chain
- [ ] `TestGenerateBash/Zsh/FishCompletion` — script content
- [ ] `TestGenerateCompletionUnknownShell` — error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)