### PR TITLE
feat: RunFunc[T any] — struct-tag CLI inference (PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 ### Build CLI in one line
 <sup>..or two</sup>
 
+### Zero-struct — the cligen way
+
+Define a struct, tag the fields, pass a function:
+
+```golang
+type Opts struct {
+    Count int    `cli:"how many times I want to say it" default:"1"`
+    Say   string `cli:"say something"                   default:"hello"`
+    World bool   `cli:"announce it to the world"`
+}
+
+func main() {
+    quicli.RunFunc("SayToTheWorld [flags]", "Say Hello...", func(o Opts) {
+        for i := 0; i < o.Count; i++ {
+            if o.World { fmt.Print("Message for the world: ") }
+            fmt.Println(o.Say)
+        }
+    })
+}
+```
+
+Supported field types: `int`, `string`, `bool`, `float64`, `[]string`.
+Tags: `cli:"desc"` (required), `default:"val"`, `short:"x"`, `env:"VAR"`.
+Untagged fields are ignored — safe to mix CLI and non-CLI fields in the same struct.
+
+### Cli struct — for subcommands and full control
 
 ```golang
 cli := quicli.Cli{Usage:"SayToTheWorld [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},}

--- a/README.md
+++ b/README.md
@@ -14,13 +14,33 @@ type Opts struct {
 }
 
 func main() {
-    quicli.RunFunc("SayToTheWorld [flags]", "Say Hello...", func(o Opts) {
+    quicli.RunFunc("say-hello [flags]", "Say Hello...", func(o Opts) {
         for i := 0; i < o.Count; i++ {
             if o.World { fmt.Print("Message for the world: ") }
             fmt.Println(o.Say)
         }
     })
 }
+```
+
+This gives you:
+```
+Say Hello...
+
+Usage: say-hello [flags]
+
+--count  -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
+--say    -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
+--world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+
+Use "say-hello --help" for more information about the command.
+```
+
+```bash
+./say-hello --count 3 --say "hi"
+./say-hello -w
+SAY_HELLO_COUNT=5 ./say-hello          # env var fallback
+./say-hello --completion bash          # print bash completion script
 ```
 
 Supported field types: `int`, `string`, `bool`, `float64`, `[]string`.
@@ -30,7 +50,7 @@ Untagged fields are ignored — safe to mix CLI and non-CLI fields in the same s
 ### Cli struct — for subcommands and full control
 
 ```golang
-cli := quicli.Cli{Usage:"SayToTheWorld [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},}
+cli := quicli.Cli{Usage:"say-hello [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},}
 cfg := cli.Parse()
 ```
 
@@ -38,13 +58,13 @@ With this code you obtain the following help message:
 ```
 Say Hello... or not. If you want to make the world aware of it you also could
 
-Usage: SayToTheWorld [flags]
+Usage: say-hello [flags]
 
---count -c              how many times I want to say it. Sometimes repetition is the key. (default: 1)
---say   -s              say something. If you are polite start with a greeting. (default: "hello")
---world -w              announce it to the world. (default: false)
+--count  -c   how many times I want to say it. Sometimes repetition is the key. (default: 1) [env: SAY_HELLO_COUNT]
+--say    -s   say something. If you are polite start with a greeting. (default: "hello") [env: SAY_HELLO_SAY]
+--world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
 
-Use "./sayhello --help" for more information about the command.
+Use "say-hello --help" for more information about the command.
 ```
 
 <details>
@@ -52,7 +72,7 @@ Use "./sayhello --help" for more information about the command.
 
 ```golang
 cli := quicli.Cli{
-  Usage:       "SayToTheWorld [flags]",
+  Usage:       "say-hello [flags]",
   Description: "Say Hello... or not. If you want to make the world aware of it you also could",
   Flags: quicli.Flags{
     {Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},
@@ -68,7 +88,7 @@ cfg := cli.Parse()
     <summary>Real one-liner (Parse and run)</summary>
 
 ```golang
-quicli.Run(quicli.Cli{Usage:"SayToTheWorld [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},Function: SayHello,})
+quicli.Run(quicli.Cli{Usage:"say-hello [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},Function: SayHello,})
 ```
 </details>
 
@@ -76,32 +96,66 @@ quicli.Run(quicli.Cli{Usage:"SayToTheWorld [flags]",Description: "Say Hello... o
     <summary>You want a subcommand pattern?! okay</summary>
 
 ```golang
-	cli := quicli.Cli{
-		Usage:       "SayToTheWorld [command] [flags]",
-		Description: "Say Hello... or not. If you want to make the world aware of it you also could",
-		Flags: quicli.Flags{
-			{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},
-			{Name: "foreground", Description: "change foreground background", SharedSubcommand: quicli.SubcommandSet{"color"}},
-			{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},
-			{Name: "world", Description: "announce it to the world"},
-			{Name: "surprise", Description: "you will see my friend", SharedSubcommand: quicli.SubcommandSet{"toto", "color"}, NotForRootCommand: true},
-		},
-		Function: Main,
-		Subcommands: quicli.Subcommands{
-			{Name: "color", Description: "print coloured message", Function: Color},
-			{Name: "toto", Description: "??", Function: Toto},
-		},
-	}
-	cli.RunWithSubcommand()
+cli := quicli.Cli{
+    Usage:       "say-hello [command] [flags]",
+    Description: "Say Hello... or not. If you want to make the world aware of it you also could",
+    Flags: quicli.Flags{
+        {Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},
+        {Name: "foreground", Description: "change foreground color", SharedSubcommand: quicli.SubcommandSet{"color"}},
+        {Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},
+        {Name: "world", Description: "announce it to the world"},
+        {Name: "surprise", Description: "you will see my friend", SharedSubcommand: quicli.SubcommandSet{"toto", "color"}, NotForRootCommand: true},
+    },
+    Function: Main,
+    Subcommands: quicli.Subcommands{
+        {Name: "color", Description: "print coloured message", Function: Color},
+        {Name: "toto", Description: "??", Function: Toto},
+    },
+}
+cli.RunWithSubcommand()
+```
+
+Root help (`./say-hello --help`):
+```
+Say Hello... or not. If you want to make the world aware of it you also could
+
+Usage: say-hello [command] [flags]
+Available commands: color, toto
+
+--count  -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
+--say    -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
+--world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+
+Use "say-hello --help" for more information about the command.
+```
+
+Subcommand help (`./say-hello color --help`):
+```
+Say Hello... or not. ...
+
+Usage: say-hello [command] [flags]
+Command color: print coloured message
+
+--count       -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
+--foreground  -f   change foreground color. (default: false) [env: SAY_HELLO_FOREGROUND]
+--say         -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
+--surprise    -S   you will see my friend. (default: false) [env: SAY_HELLO_SURPRISE]
+--world       -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+```
+
+```bash
+./say-hello color --foreground --say "hello"
+./say-hello toto --surprise
+./say-hello clour          # quicli error: unknown subcommand 'clour', did you mean 'color'?
 ```
 </details>
 
 ### Use flag values in code
 ```golang
-cfg.GetIntFlag("count")    // --count  (int)
-cfg.GetStringFlag("say")   // --say    (string)
-cfg.GetBoolFlag("world")   // --world  (bool)
-cfg.GetFloatFlag("ratio")  // --ratio  (float64)
+cfg.GetIntFlag("count")        // --count  (int)
+cfg.GetStringFlag("say")       // --say    (string)
+cfg.GetBoolFlag("world")       // --world  (bool)
+cfg.GetFloatFlag("ratio")      // --ratio  (float64)
 cfg.GetStringSliceFlag("tags") // --tags a,b --tags c  ([]string)
 // or use the short name: cfg.GetIntFlag("c")
 ```
@@ -156,9 +210,9 @@ The env var name is shown in help output: `(default: 0) [env: SAY_HELLO_COUNT]`
 Every CLI built with quicli gets `--completion <shell>` for free:
 
 ```bash
-./mycli --completion bash >> ~/.bash_completion
-./mycli --completion zsh  > ~/.zsh/completions/_mycli
-./mycli --completion fish > ~/.config/fish/completions/mycli.fish
+./say-hello --completion bash >> ~/.bash_completion
+./say-hello --completion zsh  > ~/.zsh/completions/_say-hello
+./say-hello --completion fish > ~/.config/fish/completions/say-hello.fish
 ```
 
 Get more  [examples](examples/)

--- a/pkg/quicli/runfunc.go
+++ b/pkg/quicli/runfunc.go
@@ -1,0 +1,144 @@
+package quicli
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// RunFunc builds and runs a CLI inferred from the exported fields of T.
+// T must be a struct. Fields without a `cli:` tag are ignored.
+//
+// Supported field types: int, string, bool, float64, []string.
+//
+// Tags:
+//
+//	cli:"description"  — field description (required to include the field)
+//	default:"value"    — default value as string; zero value if omitted
+//	short:"x"          — short flag name override
+//	env:"VAR"          — env var name override (use "-" to opt out)
+//
+// Example:
+//
+//	type Opts struct {
+//	    Count int    `cli:"how many times" default:"1"`
+//	    Say   string `cli:"what to say"    default:"hello"`
+//	}
+//	quicli.RunFunc("prog [flags]", "Say something", func(o Opts) {
+//	    for i := 0; i < o.Count; i++ { fmt.Println(o.Say) }
+//	})
+func RunFunc[T any](usage, description string, fn func(T)) {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() != reflect.Struct {
+		fmt.Println(QUICLI_ERROR_PREFIX + "RunFunc: T must be a struct")
+		return
+	}
+
+	flags, err := flagsFromStruct(t)
+	if err != nil {
+		fmt.Println(QUICLI_ERROR_PREFIX + err.Error())
+		return
+	}
+
+	cli := &Cli{
+		Usage:       usage,
+		Description: description,
+		Flags:       flags,
+	}
+	cfg := cli.Parse()
+	fn(populateStruct[T](t, cfg))
+}
+
+// flagsFromStruct reflects on struct type t and returns Flag definitions
+// for each exported field that has a `cli:` tag.
+func flagsFromStruct(t reflect.Type) ([]Flag, error) {
+	var flags []Flag
+	for i := range t.NumField() {
+		field := t.Field(i)
+		cliTag := field.Tag.Get("cli")
+		if cliTag == "" {
+			continue
+		}
+
+		f := Flag{
+			Name:        strings.ToLower(field.Name),
+			Description: cliTag,
+			ShortName:   field.Tag.Get("short"),
+			EnvVar:      field.Tag.Get("env"),
+		}
+
+		defaultTag := field.Tag.Get("default")
+		switch field.Type.Kind() {
+		case reflect.Int:
+			if defaultTag != "" {
+				v, err := strconv.Atoi(defaultTag)
+				if err != nil {
+					return nil, fmt.Errorf("field %s: invalid default int %q: %w", field.Name, defaultTag, err)
+				}
+				f.Default = v
+			} else {
+				f.Default = 0
+			}
+		case reflect.String:
+			f.Default = defaultTag
+		case reflect.Bool:
+			if defaultTag != "" {
+				v, err := strconv.ParseBool(defaultTag)
+				if err != nil {
+					return nil, fmt.Errorf("field %s: invalid default bool %q: %w", field.Name, defaultTag, err)
+				}
+				f.Default = v
+			} else {
+				f.Default = false
+			}
+		case reflect.Float64:
+			if defaultTag != "" {
+				v, err := strconv.ParseFloat(defaultTag, 64)
+				if err != nil {
+					return nil, fmt.Errorf("field %s: invalid default float64 %q: %w", field.Name, defaultTag, err)
+				}
+				f.Default = v
+			} else {
+				f.Default = float64(0)
+			}
+		case reflect.Slice:
+			if field.Type.Elem().Kind() != reflect.String {
+				return nil, fmt.Errorf("field %s: only []string slices are supported", field.Name)
+			}
+			f.Default = []string{}
+		default:
+			return nil, fmt.Errorf("field %s: unsupported type %s (supported: int, string, bool, float64, []string)", field.Name, field.Type.Kind())
+		}
+
+		flags = append(flags, f)
+	}
+	return flags, nil
+}
+
+// populateStruct fills a new T from Config, reading each field by its lowercased name.
+func populateStruct[T any](t reflect.Type, cfg Config) T {
+	var opts T
+	v := reflect.ValueOf(&opts).Elem()
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if field.Tag.Get("cli") == "" {
+			continue
+		}
+		name := strings.ToLower(field.Name)
+		switch field.Type.Kind() {
+		case reflect.Int:
+			v.Field(i).SetInt(int64(cfg.GetIntFlag(name)))
+		case reflect.String:
+			v.Field(i).SetString(cfg.GetStringFlag(name))
+		case reflect.Bool:
+			v.Field(i).SetBool(cfg.GetBoolFlag(name))
+		case reflect.Float64:
+			v.Field(i).SetFloat(cfg.GetFloatFlag(name))
+		case reflect.Slice:
+			v.Field(i).Set(reflect.ValueOf(cfg.GetStringSliceFlag(name)))
+		}
+	}
+	return opts
+}

--- a/pkg/quicli/runfunc_test.go
+++ b/pkg/quicli/runfunc_test.go
@@ -1,0 +1,190 @@
+package quicli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// --- flagsFromStruct tests ---
+
+type basicOpts struct {
+	Count  int      `cli:"how many times" default:"3"`
+	Say    string   `cli:"what to say" default:"hello"`
+	World  bool     `cli:"announce to the world"`
+	Ratio  float64  `cli:"scaling ratio" default:"1.5"`
+	Files  []string `cli:"input files"`
+	Ignore string   // no cli tag — must be skipped
+}
+
+func TestFlagsFromStructNames(t *testing.T) {
+	flags, err := flagsFromStruct(reflect.TypeOf(basicOpts{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flags) != 5 {
+		t.Fatalf("got %d flags, want 5 (Ignore must be skipped)", len(flags))
+	}
+	names := map[string]bool{}
+	for _, f := range flags {
+		names[f.Name] = true
+	}
+	for _, want := range []string{"count", "say", "world", "ratio", "files"} {
+		if !names[want] {
+			t.Errorf("missing flag %q", want)
+		}
+	}
+}
+
+func TestFlagsFromStructDefaults(t *testing.T) {
+	flags, err := flagsFromStruct(reflect.TypeOf(basicOpts{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]Flag{}
+	for _, f := range flags {
+		byName[f.Name] = f
+	}
+	if byName["count"].Default.(int) != 3 {
+		t.Errorf("count default: got %v, want 3", byName["count"].Default)
+	}
+	if byName["say"].Default.(string) != "hello" {
+		t.Errorf("say default: got %v, want hello", byName["say"].Default)
+	}
+	if byName["world"].Default.(bool) != false {
+		t.Errorf("world default: got %v, want false", byName["world"].Default)
+	}
+	if byName["ratio"].Default.(float64) != 1.5 {
+		t.Errorf("ratio default: got %v, want 1.5", byName["ratio"].Default)
+	}
+}
+
+func TestFlagsFromStructTags(t *testing.T) {
+	type tagged struct {
+		Name string `cli:"your name" short:"n" env:"MY_NAME"`
+	}
+	flags, err := flagsFromStruct(reflect.TypeOf(tagged{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flags) != 1 {
+		t.Fatalf("got %d flags, want 1", len(flags))
+	}
+	f := flags[0]
+	if f.ShortName != "n" {
+		t.Errorf("ShortName: got %q, want n", f.ShortName)
+	}
+	if f.EnvVar != "MY_NAME" {
+		t.Errorf("EnvVar: got %q, want MY_NAME", f.EnvVar)
+	}
+}
+
+func TestFlagsFromStructBadDefault(t *testing.T) {
+	type bad struct {
+		Count int `cli:"count" default:"notanint"`
+	}
+	_, err := flagsFromStruct(reflect.TypeOf(bad{}))
+	if err == nil {
+		t.Error("expected error for invalid default int")
+	}
+}
+
+// --- RunFunc end-to-end tests ---
+
+func TestRunFuncInt(t *testing.T) {
+	defer setArgs([]string{"prog", "--count", "5"})()
+	type Opts struct {
+		Count int `cli:"how many times" default:"1"`
+	}
+	var got int
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.Count
+	})
+	if got != 5 {
+		t.Errorf("RunFunc int: got %d, want 5", got)
+	}
+}
+
+func TestRunFuncString(t *testing.T) {
+	defer setArgs([]string{"prog", "--say", "world"})()
+	type Opts struct {
+		Say string `cli:"what to say" default:"hello"`
+	}
+	var got string
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.Say
+	})
+	if got != "world" {
+		t.Errorf("RunFunc string: got %q, want world", got)
+	}
+}
+
+func TestRunFuncDefaultUsed(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	type Opts struct {
+		Say string `cli:"what to say" default:"hello"`
+	}
+	var got string
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.Say
+	})
+	if got != "hello" {
+		t.Errorf("RunFunc default: got %q, want hello", got)
+	}
+}
+
+func TestRunFuncBool(t *testing.T) {
+	defer setArgs([]string{"prog", "--verbose"})()
+	type Opts struct {
+		Verbose bool `cli:"enable verbose output"`
+	}
+	var got bool
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.Verbose
+	})
+	if !got {
+		t.Error("RunFunc bool: expected true")
+	}
+}
+
+func TestRunFuncSkipsUntaggedFields(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	type Opts struct {
+		Count    int    `cli:"count" default:"1"`
+		Internal string // no tag — must be skipped, zero value
+	}
+	var gotInternal string
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		gotInternal = o.Internal
+	})
+	if gotInternal != "" {
+		t.Errorf("untagged field should be zero, got %q", gotInternal)
+	}
+}
+
+func TestRunFuncFloat(t *testing.T) {
+	defer setArgs([]string{"prog", "--ratio", "2.5"})()
+	type Opts struct {
+		Ratio float64 `cli:"scaling ratio" default:"1.0"`
+	}
+	var got float64
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.Ratio
+	})
+	if got != 2.5 {
+		t.Errorf("RunFunc float64: got %f, want 2.5", got)
+	}
+}
+
+func TestRunFuncSlice(t *testing.T) {
+	defer setArgs([]string{"prog", "--file", "a", "--file", "b"})()
+	type Opts struct {
+		File []string `cli:"input files"`
+	}
+	var got []string
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		got = o.File
+	})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("RunFunc slice: got %v, want [a b]", got)
+	}
+}


### PR DESCRIPTION
## Summary

- New `RunFunc[T any](usage, description string, fn func(T))` entry point
- Derives flags from struct fields tagged with `cli:"description"` — no explicit `Flags:` list needed
- `default:"val"`, `short:"x"`, `env:"VAR"` tags map to existing `Flag` fields
- After parsing, struct is populated automatically — no `cfg.GetXxxFlag()` calls needed
- Supports `int`, `string`, `bool`, `float64`, `[]string` field types
- Untagged fields stay zero-value — safe to mix CLI and non-CLI fields
- No new dependencies — pure stdlib `reflect`

**Depends on:** #10 (lands PR2 on main)

## Test plan

- [ ] `go test ./pkg/quicli/... -v` — 27 tests, all pass
- [ ] `TestFlagsFromStructNames/Defaults/Tags/BadDefault` — reflection logic
- [ ] `TestRunFuncInt/String/Bool/Float/Slice/Default/SkipsUntagged` — end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)