### PR TITLE
docs: README rewrite + RunFunc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,221 +1,169 @@
 ## 🏃⌨️ quicli
-### Build CLI in one line
-<sup>..or two</sup>
+### Build CLI in Go without the ceremony
 
-### Zero-struct — the cligen way
+No init functions. No command registration. No flag pointers.
+Define your CLI in one expression — or just tag a struct.
 
-Define a struct, tag the fields, pass a function:
+Inspired by [nim's cligen](https://github.com/c-blake/cligen).
+
+---
+
+### The zero-boilerplate way
+
+Tag a struct, pass a function. Your flags are already in `o` — no `GetXxxFlag` calls:
 
 ```golang
 type Opts struct {
-    Count int    `cli:"how many times I want to say it" default:"1"`
-    Say   string `cli:"say something"                   default:"hello"`
-    World bool   `cli:"announce it to the world"`
+    Count int      `cli:"how many times"    default:"1"`
+    Say   string   `cli:"what to say"       default:"hello"`
+    World bool     `cli:"announce it"`
+    Tags  []string `cli:"filter by tags"`
 }
 
 func main() {
-    quicli.RunFunc("say-hello [flags]", "Say Hello...", func(o Opts) {
+    quicli.RunFunc("say-hello [flags]", "Say Hello to the world", func(o Opts) {
         for i := 0; i < o.Count; i++ {
-            if o.World { fmt.Print("Message for the world: ") }
-            fmt.Println(o.Say)
+            msg := o.Say
+            if o.World { msg = "🌍 " + msg }
+            fmt.Println(msg)
         }
     })
 }
 ```
 
-This gives you:
 ```
-Say Hello...
+$ say-hello --help
+
+Say Hello to the world
 
 Usage: say-hello [flags]
 
---count  -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
---say    -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
---world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+--count  -c   how many times. (default: 1) [env: SAY_HELLO_COUNT]
+--say    -s   what to say. (default: "hello") [env: SAY_HELLO_SAY]
+--world  -w   announce it. (default: false) [env: SAY_HELLO_WORLD]
+--tags   -t   filter by tags. (default: []) [env: SAY_HELLO_TAGS]
 
 Use "say-hello --help" for more information about the command.
 ```
 
 ```bash
-./say-hello --count 3 --say "hi"
-./say-hello -w
-SAY_HELLO_COUNT=5 ./say-hello          # env var fallback
-./say-hello --completion bash          # print bash completion script
+$ say-hello --count 3 --say "bonjour"
+$ say-hello -w
+$ SAY_HELLO_COUNT=5 say-hello          # env var, same as --count 5
+$ say-hello --completion zsh           # print zsh completion script
 ```
 
 Supported field types: `int`, `string`, `bool`, `float64`, `[]string`.
-Tags: `cli:"desc"` (required), `default:"val"`, `short:"x"`, `env:"VAR"`.
-Untagged fields are ignored — safe to mix CLI and non-CLI fields in the same struct.
+Tags: `cli:"desc"` · `default:"val"` · `short:"x"` · `env:"VAR"` (or `"-"` to opt out).
 
-### Cli struct — for subcommands and full control
+---
 
-```golang
-cli := quicli.Cli{Usage:"say-hello [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},}
-cfg := cli.Parse()
-```
+### The one-liner way
 
-With this code you obtain the following help message:
-```
-Say Hello... or not. If you want to make the world aware of it you also could
-
-Usage: say-hello [flags]
-
---count  -c   how many times I want to say it. Sometimes repetition is the key. (default: 1) [env: SAY_HELLO_COUNT]
---say    -s   say something. If you are polite start with a greeting. (default: "hello") [env: SAY_HELLO_SAY]
---world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
-
-Use "say-hello --help" for more information about the command.
-```
-
-<details>
-    <summary>Pretty indented version</summary>
+Everything in one expression:
 
 ```golang
-cli := quicli.Cli{
-  Usage:       "say-hello [flags]",
-  Description: "Say Hello... or not. If you want to make the world aware of it you also could",
-  Flags: quicli.Flags{
-    {Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},
-    {Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},
-    {Name: "world", Description: "announce it to the world"},
-  },
-}
-cfg := cli.Parse()
-```
-</details>
-
-<details>
-    <summary>Real one-liner (Parse and run)</summary>
-
-```golang
-quicli.Run(quicli.Cli{Usage:"say-hello [flags]",Description: "Say Hello... or not. If you want to make the world aware of it you also could",Flags: quicli.Flags{{Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},{Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},{Name: "world", Description: "announce it to the world"},},Function: SayHello,})
-```
-</details>
-
-<details>
-    <summary>You want a subcommand pattern?! okay</summary>
-
-```golang
-cli := quicli.Cli{
-    Usage:       "say-hello [command] [flags]",
-    Description: "Say Hello... or not. If you want to make the world aware of it you also could",
+quicli.Run(quicli.Cli{
+    Usage:       "say-hello [flags]",
+    Description: "Say Hello to the world",
     Flags: quicli.Flags{
-        {Name: "count", Default: 1, Description: "how many times I want to say it. Sometimes repetition is the key"},
-        {Name: "foreground", Description: "change foreground color", SharedSubcommand: quicli.SubcommandSet{"color"}},
-        {Name: "say", Default: "hello", Description: "say something. If you are polite start with a greeting"},
-        {Name: "world", Description: "announce it to the world"},
-        {Name: "surprise", Description: "you will see my friend", SharedSubcommand: quicli.SubcommandSet{"toto", "color"}, NotForRootCommand: true},
+        {Name: "count", Default: 1,       Description: "how many times"},
+        {Name: "say",   Default: "hello", Description: "what to say"},
+        {Name: "world",                   Description: "announce it"},
     },
-    Function: Main,
+    Function: func(cfg quicli.Config) {
+        count := cfg.GetIntFlag("count")
+        say   := cfg.GetStringFlag("say")
+        world := cfg.GetBoolFlag("world")
+        for i := 0; i < count; i++ {
+            if world { fmt.Print("🌍 ") }
+            fmt.Println(say)
+        }
+    },
+})
+```
+
+<details>
+<summary>With subcommands</summary>
+
+```golang
+quicli.Cli{
+    Usage:       "mytool [command] [flags]",
+    Description: "A tool that does things",
+    Flags: quicli.Flags{
+        {Name: "verbose", Description: "verbose output"},
+        {Name: "output",  Default: "text", Description: "output format",
+            SharedSubcommand: quicli.SubcommandSet{"get", "list"}},
+    },
+    Function: Root,
     Subcommands: quicli.Subcommands{
-        {Name: "color", Description: "print coloured message", Function: Color},
-        {Name: "toto", Description: "??", Function: Toto},
+        {Name: "get",    Aliases: quicli.Aliases("g"),  Description: "get a resource",  Function: Get,
+            Flags: quicli.Flags{{Name: "id", Default: "", Description: "resource id"}}},
+        {Name: "list",   Aliases: quicli.Aliases("ls"), Description: "list resources",  Function: List},
+        {Name: "delete",                                 Description: "delete a resource", Function: Delete},
     },
-}
-cli.RunWithSubcommand()
+}.RunWithSubcommand()
 ```
 
-Root help (`./say-hello --help`):
 ```
-Say Hello... or not. If you want to make the world aware of it you also could
+$ mytool --help
 
-Usage: say-hello [command] [flags]
-Available commands: color, toto
+A tool that does things
 
---count  -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
---say    -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
---world  -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+Usage: mytool [command] [flags]
+Available commands: get, g, list, ls, delete
 
-Use "say-hello --help" for more information about the command.
-```
+--verbose  -v   verbose output. (default: false) [env: MYTOOL_VERBOSE]
 
-Subcommand help (`./say-hello color --help`):
-```
-Say Hello... or not. ...
+Use "mytool --help" for more information about the command.
 
-Usage: say-hello [command] [flags]
-Command color: print coloured message
+$ mytool get --help
 
---count       -c   how many times I want to say it. (default: 1) [env: SAY_HELLO_COUNT]
---foreground  -f   change foreground color. (default: false) [env: SAY_HELLO_FOREGROUND]
---say         -s   say something. (default: "hello") [env: SAY_HELLO_SAY]
---surprise    -S   you will see my friend. (default: false) [env: SAY_HELLO_SURPRISE]
---world       -w   announce it to the world. (default: false) [env: SAY_HELLO_WORLD]
+Command get: get a resource
+
+--id      -i   resource id. (default: "") [env: MYTOOL_ID]
+--output  -o   output format. (default: "text") [env: MYTOOL_OUTPUT]
+--verbose -v   verbose output. (default: false) [env: MYTOOL_VERBOSE]
 ```
 
 ```bash
-./say-hello color --foreground --say "hello"
-./say-hello toto --surprise
-./say-hello clour          # quicli error: unknown subcommand 'clour', did you mean 'color'?
+$ mytool get --id abc123
+$ mytool g --id abc123         # alias works
+$ mytool lst                   # quicli error: unknown subcommand 'lst', did you mean 'list'?
+$ MYTOOL_VERBOSE=true mytool list
 ```
+
 </details>
 
-### Use flag values in code
-```golang
-cfg.GetIntFlag("count")        // --count  (int)
-cfg.GetStringFlag("say")       // --say    (string)
-cfg.GetBoolFlag("world")       // --world  (bool)
-cfg.GetFloatFlag("ratio")      // --ratio  (float64)
-cfg.GetStringSliceFlag("tags") // --tags a,b --tags c  ([]string)
-// or use the short name: cfg.GetIntFlag("c")
-```
+---
 
-**Custom short name** — override the auto-derived first letter:
-```golang
-{Name: "config", ShortName: "C", Default: "", Description: "config file"}
-// registers --config and -C
-```
+### Batteries included
 
-**Per-subcommand exclusive flags** — flags that only exist for one subcommand:
-```golang
-Subcommands: quicli.Subcommands{
-    {
-        Name: "push", Description: "push changes", Function: Push,
-        Flags: quicli.Flags{
-            {Name: "force", Description: "force push"},
-        },
-    },
-},
-```
+Every quicli CLI gets these for free — no configuration needed:
 
-**Typo detection** — if a user types an unknown subcommand, quicli automatically suggests the closest match:
-```
-$ mytool pish
-quicli error: unknown subcommand 'pish', did you mean 'push'?
-```
-
-### Env vars
-
-Every flag automatically reads from an env var as fallback before using the default.
-Auto-derived name: `PROGNAME_FLAGNAME` (uppercase, non-alphanumeric → `_`).
-
+**Env var fallback** — `PROGNAME_FLAGNAME` is checked before the default. Shown in help.
 ```bash
-SAY_HELLO_COUNT=5 ./say-hello   # same as --count 5
+SAY_HELLO_COUNT=10 ./say-hello    # same as --count 10
 ```
+Override per flag: `EnvVar: "MY_CUSTOM_VAR"` · Opt out: `EnvVar: "-"`
 
-Override the env var name per flag:
-```golang
-{Name: "token", Default: "", Description: "API token", EnvVar: "MY_API_TOKEN"}
-```
+**Short flags** — first letter auto-derived (`--count` → `-c`). Override with `ShortName: "n"`.
 
-Opt a flag out of env var lookup:
-```golang
-{Name: "secret", Default: "", Description: "...", EnvVar: "-"}
-```
-
-The env var name is shown in help output: `(default: 0) [env: SAY_HELLO_COUNT]`
-
-### Shell completion
-
-Every CLI built with quicli gets `--completion <shell>` for free:
-
+**Shell completion** — one flag, three shells:
 ```bash
 ./say-hello --completion bash >> ~/.bash_completion
-./say-hello --completion zsh  > ~/.zsh/completions/_say-hello
-./say-hello --completion fish > ~/.config/fish/completions/say-hello.fish
+./say-hello --completion zsh  >  ~/.zsh/completions/_say-hello
+./say-hello --completion fish >  ~/.config/fish/completions/say-hello.fish
 ```
 
-Get more  [examples](examples/)
+**Typo detection** — suggests the closest subcommand on misspelling:
+```
+$ mytool delet
+quicli error: unknown subcommand 'delet', did you mean 'delete'?
+```
 
-### Disclaimer
-The library is a wrapper of the built-in go `flag` package. It should only be used to quickly built CLI and it is not intented for complex CLI usage.
+---
+
+Get more [examples](examples/)
+
+> quicli is a thin wrapper around Go's `flag` package. Use it to write CLIs fast, not to build complex command hierarchies.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ### Build CLI in Go without the ceremony
 
 No init functions. No command registration. No flag pointers.
-Define your CLI in one expression — or just tag a struct.
+Define your CLI in one expression *(or just tag a struct)*
 
 Inspired by [nim's cligen](https://github.com/c-blake/cligen).
 
@@ -10,7 +10,7 @@ Inspired by [nim's cligen](https://github.com/c-blake/cligen).
 
 ### The zero-boilerplate way
 
-Tag a struct, pass a function. Your flags are already in `o` — no `GetXxxFlag` calls:
+Tag a struct, pass a function. Your flags are already in `Opts` Struct:
 
 ```golang
 type Opts struct {

--- a/examples/resources.go
+++ b/examples/resources.go
@@ -1,0 +1,125 @@
+//go:build ignore
+
+// resources — a fake resource manager demonstrating the subcommand pattern:
+// get, list, delete with shared and exclusive flags, aliases, and typo detection.
+//
+// Try:
+//   go run examples/resources.go --help
+//   go run examples/resources.go get --help
+//   go run examples/resources.go get --id abc123
+//   go run examples/resources.go g --id abc123 --verbose
+//   go run examples/resources.go list --output json
+//   go run examples/resources.go ls
+//   go run examples/resources.go delete --id abc123
+//   go run examples/resources.go delet    # typo detection
+//   RESOURCES_VERBOSE=true go run examples/resources.go list
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+var db = map[string]string{
+	"abc123": "widget",
+	"def456": "gadget",
+	"ghi789": "doohickey",
+}
+
+func cmdGet(cfg q.Config) {
+	id := cfg.GetStringFlag("id")
+	if id == "" {
+		fmt.Println("error: --id is required")
+		return
+	}
+	name, ok := db[id]
+	if !ok {
+		fmt.Printf("not found: %s\n", id)
+		return
+	}
+	if cfg.GetBoolFlag("verbose") {
+		fmt.Printf("id:   %s\nname: %s\n", id, name)
+	} else {
+		fmt.Println(name)
+	}
+}
+
+func cmdList(cfg q.Config) {
+	output := cfg.GetStringFlag("output")
+	verbose := cfg.GetBoolFlag("verbose")
+	switch output {
+	case "json":
+		parts := []string{}
+		for id, name := range db {
+			parts = append(parts, fmt.Sprintf(`{"id":%q,"name":%q}`, id, name))
+		}
+		fmt.Println("[" + strings.Join(parts, ",") + "]")
+	default:
+		for id, name := range db {
+			if verbose {
+				fmt.Printf("%-10s %s\n", id, name)
+			} else {
+				fmt.Println(name)
+			}
+		}
+	}
+}
+
+func cmdDelete(cfg q.Config) {
+	id := cfg.GetStringFlag("id")
+	if id == "" {
+		fmt.Println("error: --id is required")
+		return
+	}
+	if _, ok := db[id]; !ok {
+		fmt.Printf("not found: %s\n", id)
+		return
+	}
+	delete(db, id)
+	fmt.Printf("deleted %s\n", id)
+}
+
+func cmdRoot(cfg q.Config) {
+	fmt.Println("use a subcommand: get, list, delete")
+}
+
+func main() {
+	cli := q.Cli{
+		Usage:       "resources [command] [flags]",
+		Description: "Manage resources",
+		Flags: q.Flags{
+			{Name: "verbose", Description: "verbose output",
+				SharedSubcommand: q.SubcommandSet{"get", "list", "delete"}},
+			{Name: "output", Default: "text", Description: "output format (text, json)",
+				SharedSubcommand: q.SubcommandSet{"list"}},
+		},
+		Function: cmdRoot,
+		Subcommands: q.Subcommands{
+			{
+				Name: "get", Aliases: q.Aliases("g"),
+				Description: "get a resource by id",
+				Function:    cmdGet,
+				Flags: q.Flags{
+					{Name: "id", Default: "", Description: "resource id"},
+				},
+			},
+			{
+				Name: "list", Aliases: q.Aliases("ls"),
+				Description: "list all resources",
+				Function:    cmdList,
+			},
+			{
+				Name:        "delete",
+				Description: "delete a resource by id",
+				Function:    cmdDelete,
+				Flags: q.Flags{
+					{Name: "id", Default: "", Description: "resource id"},
+				},
+			},
+		},
+	}
+	cli.RunWithSubcommand()
+}

--- a/examples/sayhello_runfunc.go
+++ b/examples/sayhello_runfunc.go
@@ -1,0 +1,55 @@
+//go:build ignore
+
+// sayhello_runfunc — demonstrates RunFunc: define a struct with cli tags,
+// pass a function, done. No flag registration, no GetXxxFlag calls.
+//
+// Try:
+//   go run examples/sayhello_runfunc.go --help
+//   go run examples/sayhello_runfunc.go --count 3 --say "bonjour"
+//   go run examples/sayhello_runfunc.go -w --tags en --tags fr
+//   go run examples/sayhello_runfunc.go --volume 0.3 --say "whisper"
+//   SAY_HELLO_COUNT=5 go run examples/sayhello_runfunc.go
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+// Opts defines the full CLI through struct tags — no Flags slice needed.
+type Opts struct {
+	Count  int      `cli:"how many times to say it"    default:"1"`
+	Say    string   `cli:"what to say"                 default:"hello"`
+	World  bool     `cli:"prefix with a world message"`
+	Tags   []string `cli:"filter output by tags"`
+	Volume float64  `cli:"output volume: 0.0 quiet, 1.0 loud" default:"1.0" short:"V"`
+}
+
+func main() {
+	q.RunFunc("say-hello [flags]", "Say Hello to the world", func(o Opts) {
+		prefix := ""
+		if o.World {
+			prefix = "🌍 "
+		}
+
+		for i := 0; i < o.Count; i++ {
+			line := prefix + o.Say
+			if len(o.Tags) > 0 {
+				line += " [" + strings.Join(o.Tags, ", ") + "]"
+			}
+			switch {
+			case o.Volume == 0:
+				// silent
+			case o.Volume < 0.5:
+				fmt.Println(strings.ToLower(line))
+			case o.Volume == 1.0:
+				fmt.Println(strings.ToUpper(line))
+			default:
+				fmt.Println(line)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **README rewrite** — stronger hook, cleaner structure, better examples:
  - Opens with the value prop ("no init, no registration, no flag pointers") + credits nim cligen
  - Two named paths: *zero-boilerplate* (`RunFunc`) and *one-liner* (`Cli` struct)
  - `RunFunc` calls out that the struct is already populated — no `GetXxxFlag` calls needed
  - Subcommand section uses `get/list/delete` with real aliases, not toy names
  - "Batteries included" consolidates env vars, short flags, completion, typo detection
  - Disclaimer reframed as a short blockquote

- **New `examples/sayhello_runfunc.go`** — `RunFunc` with all five field types (`int`, `string`, `bool`, `float64`, `[]string`) and a custom `short:"V"` tag

- **New `examples/resources.go`** — subcommand pattern: `get` / `list` / `delete` with aliases (`g`, `ls`), shared `--verbose`, `--output` scoped to `list`, exclusive `--id` flags on `get`/`delete`, typo detection

- **Fix `examples/sayhello_subcommand.go`** — `ForSubcommand` → `SharedSubcommand`

## Test plan
- [ ] `go run examples/sayhello_runfunc.go --help`
- [ ] `go run examples/sayhello_runfunc.go --count 2 -w --tags a --tags b`
- [ ] `go run examples/resources.go --help`
- [ ] `go run examples/resources.go list --output json`
- [ ] `go run examples/resources.go g --id abc123 --verbose`
- [ ] `go run examples/resources.go delet` → typo suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)