### PR TITLE
feat: NewSubcommand[T] — zero-boilerplate subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,49 @@ $ say-hello --completion zsh           # print zsh completion script
 Supported field types: `int`, `string`, `bool`, `float64`, `[]string`.
 Tags: `cli:"desc"` · `default:"val"` · `short:"x"` · `env:"VAR"` (or `"-"` to opt out).
 
+<details>
+<summary>With subcommands</summary>
+
+Give each subcommand its own struct. `NewSubcommand` infers the flags from it:
+
+```golang
+type ColorOpts struct {
+    Foreground bool `cli:"use foreground color"`
+}
+
+type WhisperOpts struct {
+    Say   string `cli:"what to whisper" default:"psst"`
+    Times int    `cli:"how many times"  default:"1"`
+}
+
+func main() {
+    colorSub := quicli.NewSubcommand("color", "print in red", func(o ColorOpts) {
+        fmt.Println("foreground:", o.Foreground)
+    })
+    colorSub.Aliases = quicli.Aliases("co")   // optional
+
+    quicli.Cli{
+        Usage:       "say-hello [command] [flags]",
+        Description: "Say Hello to the world",
+        Function:    func(cfg quicli.Config) { fmt.Println("hello") },
+        Subcommands: quicli.Subcommands{
+            colorSub,
+            quicli.NewSubcommand("whisper", "say quietly", func(o WhisperOpts) {
+                for i := 0; i < o.Times; i++ { fmt.Println(o.Say) }
+            }),
+        },
+    }.RunWithSubcommand()
+}
+```
+
+```bash
+$ say-hello color --foreground
+$ say-hello co --foreground      # alias works
+$ say-hello whisper --say "shhh" --times 2
+```
+
+</details>
+
 ---
 
 ### The one-liner way

--- a/examples/sayhello_runfunc_subcommand.go
+++ b/examples/sayhello_runfunc_subcommand.go
@@ -1,0 +1,68 @@
+//go:build ignore
+
+// sayhello_runfunc_subcommand — demonstrates NewSubcommand: define per-subcommand
+// structs with cli tags, pass typed functions, done. No flag registration, no
+// GetXxxFlag calls, no manual Subcommand.Flags slice.
+//
+// Try:
+//
+//	go run examples/sayhello_runfunc_subcommand.go --help
+//	go run examples/sayhello_runfunc_subcommand.go --count 3
+//	go run examples/sayhello_runfunc_subcommand.go color --foreground
+//	go run examples/sayhello_runfunc_subcommand.go whisper --say "shhh" --times 2
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+type MainOpts struct {
+	Count int    `cli:"how many times to say it" default:"1"`
+	Say   string `cli:"what to say"              default:"hello"`
+}
+
+type ColorOpts struct {
+	Foreground bool `cli:"use foreground color instead of background"`
+}
+
+type WhisperOpts struct {
+	Say   string `cli:"what to whisper" default:"psst"`
+	Times int    `cli:"how many times"  default:"1"`
+}
+
+func main() {
+	colorSub := q.NewSubcommand("color", "print in red", func(o ColorOpts) {
+		if o.Foreground {
+			fmt.Println("\033[31mHELLO WORLD\033[0m") // red foreground
+		} else {
+			fmt.Println("\033[41mHELLO WORLD\033[0m") // red background
+		}
+	})
+	colorSub.Aliases = q.Aliases("co")
+
+	cli := q.Cli{
+		Usage:       "say-hello [command] [flags]",
+		Description: "Say Hello to the world — zero-boilerplate subcommands",
+		Flags: q.Flags{
+			{Name: "count", Default: 1, Description: "how many times (root command)"},
+		},
+		Function: func(cfg q.Config) {
+			for i := 0; i < cfg.GetIntFlag("count"); i++ {
+				fmt.Println("HELLO WORLD")
+			}
+		},
+		Subcommands: q.Subcommands{
+			colorSub,
+			q.NewSubcommand("whisper", "say something quietly", func(o WhisperOpts) {
+				for i := 0; i < o.Times; i++ {
+					fmt.Println(strings.ToLower(o.Say) + "…")
+				}
+			}),
+		},
+	}
+	cli.RunWithSubcommand()
+}

--- a/pkg/quicli/runfunc.go
+++ b/pkg/quicli/runfunc.go
@@ -2,6 +2,7 @@ package quicli
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -115,6 +116,44 @@ func flagsFromStruct(t reflect.Type) ([]Flag, error) {
 		flags = append(flags, f)
 	}
 	return flags, nil
+}
+
+// NewSubcommand builds a Subcommand whose flags are inferred from the exported
+// fields of T that carry a `cli:` tag — the same rules as RunFunc.
+// The inferred flags become exclusive to this subcommand (Subcommand.Flags).
+//
+// Example:
+//
+//	type ColorOpts struct {
+//	    Foreground bool `cli:"use foreground color"`
+//	    Surprise   bool `cli:"loop forever"`
+//	}
+//	sub := quicli.NewSubcommand("color", "print coloured message", func(o ColorOpts) {
+//	    fmt.Println("foreground:", o.Foreground)
+//	})
+//	// optionally add aliases: sub.Aliases = quicli.Aliases("co", "x")
+func NewSubcommand[T any](name, description string, fn func(T)) Subcommand {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() != reflect.Struct {
+		fmt.Println(QUICLI_ERROR_PREFIX + "NewSubcommand: T must be a struct")
+		os.Exit(2)
+	}
+
+	flags, err := flagsFromStruct(t)
+	if err != nil {
+		fmt.Println(QUICLI_ERROR_PREFIX + err.Error())
+		os.Exit(2)
+	}
+
+	return Subcommand{
+		Name:        name,
+		Description: description,
+		Flags:       flags,
+		Function: func(cfg Config) {
+			fn(populateStruct[T](t, cfg))
+		},
+	}
 }
 
 // populateStruct fills a new T from Config, reading each field by its lowercased name.

--- a/pkg/quicli/runfunc_test.go
+++ b/pkg/quicli/runfunc_test.go
@@ -188,3 +188,84 @@ func TestRunFuncSlice(t *testing.T) {
 		t.Errorf("RunFunc slice: got %v, want [a b]", got)
 	}
 }
+
+// --- NewSubcommand tests ---
+
+func TestNewSubcommandMetadata(t *testing.T) {
+	type ColorOpts struct {
+		Foreground bool `cli:"use foreground color"`
+		Repeat     int  `cli:"how many times" default:"1"`
+	}
+	sub := NewSubcommand("color", "print coloured message", func(o ColorOpts) {})
+
+	if sub.Name != "color" {
+		t.Errorf("Name: got %q, want color", sub.Name)
+	}
+	if sub.Description != "print coloured message" {
+		t.Errorf("Description: got %q, want 'print coloured message'", sub.Description)
+	}
+	if len(sub.Flags) != 2 {
+		t.Errorf("got %d flags, want 2", len(sub.Flags))
+	}
+	if sub.Function == nil {
+		t.Error("Function must not be nil")
+	}
+}
+
+func TestNewSubcommandIntegration(t *testing.T) {
+	defer setArgs([]string{"prog", "greet", "--name", "World", "--count", "3"})()
+
+	type GreetOpts struct {
+		Name  string `cli:"who to greet" default:"stranger"`
+		Count int    `cli:"how many times" default:"1"`
+	}
+
+	var gotName string
+	var gotCount int
+
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Function:    func(cfg Config) {},
+		Subcommands: Subcommands{
+			NewSubcommand("greet", "greet someone", func(o GreetOpts) {
+				gotName = o.Name
+				gotCount = o.Count
+			}),
+		},
+	}
+	cli.RunWithSubcommand()
+
+	if gotName != "World" {
+		t.Errorf("Name: got %q, want World", gotName)
+	}
+	if gotCount != 3 {
+		t.Errorf("Count: got %d, want 3", gotCount)
+	}
+}
+
+func TestNewSubcommandDefaultsUsed(t *testing.T) {
+	defer setArgs([]string{"prog", "greet"})()
+
+	type GreetOpts struct {
+		Name string `cli:"who to greet" default:"stranger"`
+	}
+
+	var gotName string
+
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Function:    func(cfg Config) {},
+		Subcommands: Subcommands{
+			NewSubcommand("greet", "greet someone", func(o GreetOpts) {
+				gotName = o.Name
+			}),
+		},
+	}
+	cli.RunWithSubcommand()
+
+	if gotName != "stranger" {
+		t.Errorf("default: got %q, want stranger", gotName)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `NewSubcommand[T any](name, description string, fn func(T)) Subcommand` to `runfunc.go`
- Infers exclusive subcommand flags from `cli:` struct tags (same rules as `RunFunc`)
- Wraps `func(T)` into a `Runner` via `populateStruct[T]` — no `GetXxxFlag` calls needed
- Aliases still work: set `sub.Aliases = quicli.Aliases(...)` on the returned struct
- Adds 3 tests and a new example (`sayhello_runfunc_subcommand.go`)
- Documents the pattern in README under a `<details>` block in the zero-boilerplate section

## Test plan

- [ ] `go test ./pkg/quicli/...` passes (all existing + 3 new `TestNewSubcommand*` tests)
- [ ] `go run examples/sayhello_runfunc_subcommand.go --help` shows subcommands
- [ ] `go run examples/sayhello_runfunc_subcommand.go color --foreground` works
- [ ] `go run examples/sayhello_runfunc_subcommand.go whisper --say "shhh" --times 2` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)