### PR TITLE
refactor: remove golang-set dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/ariary/quicli
 
 go 1.22
 
-require (
-	github.com/ariary/go-utils v1.0.16
-	github.com/deckarep/golang-set/v2 v2.3.1
-)
+require github.com/ariary/go-utils v1.0.16

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/ariary/go-utils v1.0.16 h1:kNyr1uGbog9aqBS8Uth1AZSfeNR4Hgv1O8UXDpnomfs=
 github.com/ariary/go-utils v1.0.16/go.mod h1:3gpTQLFaOsiZkHnCOAadPiY75nnETNYG7vOq5/o9vRk=
-github.com/deckarep/golang-set/v2 v2.3.1 h1:vjmkvJt/IV27WXPyYQpAh4bRyWJc5Y435D17XQ9QU5A=
-github.com/deckarep/golang-set/v2 v2.3.1/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=

--- a/pkg/quicli/completion.go
+++ b/pkg/quicli/completion.go
@@ -30,9 +30,7 @@ func allSubcommandNames(subs Subcommands) []string {
 	var names []string
 	for _, s := range subs {
 		names = append(names, s.Name)
-		if s.Aliases != nil {
-			names = append(names, s.Aliases.ToSlice()...)
-		}
+		names = append(names, s.Aliases...)
 	}
 	return names
 }
@@ -132,7 +130,7 @@ func generateFishCompletion(c *Cli) string {
 		fmt.Fprintf(&b, "complete -c %s -n \"__fish_use_subcommand\" -f -a %s -d '%s'\n",
 			prog, s.Name, s.Description)
 		if s.Aliases != nil {
-			for _, alias := range s.Aliases.ToSlice() {
+			for _, alias := range s.Aliases {
 				fmt.Fprintf(&b, "complete -c %s -n \"__fish_use_subcommand\" -f -a %s -d '%s (alias)'\n",
 					prog, alias, s.Description)
 			}

--- a/pkg/quicli/levenshtein.go
+++ b/pkg/quicli/levenshtein.go
@@ -33,11 +33,9 @@ func findClosestSubcommand(subcommands Subcommands, input string) string {
 		if d := levenshtein(input, s.Name); d < bestDist {
 			best, bestDist = s.Name, d
 		}
-		if s.Aliases != nil {
-			for _, a := range s.Aliases.ToSlice() {
-				if d := levenshtein(input, a); d < bestDist {
-					best, bestDist = s.Name, d
-				}
+		for _, a := range s.Aliases {
+			if d := levenshtein(input, a); d < bestDist {
+				best, bestDist = s.Name, d
 			}
 		}
 	}

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -9,23 +9,19 @@ import (
 	"text/tabwriter"
 
 	"github.com/ariary/go-utils/pkg/color"
-	mapset "github.com/deckarep/golang-set/v2"
 )
 
 // Subcommand
 type Subcommand struct {
 	Name        string
-	Aliases     mapset.Set[string]
+	Aliases     []string
 	Description string
 	Function    Runner
 	Flags       []Flag // flags exclusive to this subcommand
 }
 
-func Aliases(aliases ...string) (aliasesSet mapset.Set[string]) {
-	aliasesSet = mapset.NewSet[string]()
-	aliasesSet.Append(aliases...)
-
-	return aliasesSet
+func Aliases(aliases ...string) []string {
+	return aliases
 }
 
 type Subcommands []Subcommand
@@ -48,9 +44,7 @@ func (c *Cli) RunWithSubcommand() {
 			subcommandSet := []string{}
 			for _, sub := range c.Subcommands {
 				subcommandSet = append(subcommandSet, sub.Name)
-				if sub.Aliases != nil {
-					subcommandSet = append(subcommandSet, sub.Aliases.ToSlice()...)
-				}
+				subcommandSet = append(subcommandSet, sub.Aliases...)
 			}
 			fmt.Fprintf(wUsage, color.Yellow(c.Description)+"\n\nUsage: "+c.Usage+"\nAvailable commands: "+strings.Join(subcommandSet, ", ")+"\n\n")
 		} else {
@@ -72,8 +66,7 @@ func (c *Cli) RunWithSubcommand() {
 	//Subcommands preliminary checks
 	if len(c.Subcommands) > 0 {
 		checkSubcommandFunctionIsDefined(c)
-		allAliases := mapset.NewSet[string]()
-		checkSubcommandAliasesUniqueness(c, allAliases)
+		checkSubcommandAliasesUniqueness(c)
 	}
 
 	//flags
@@ -98,9 +91,7 @@ func (c *Cli) RunWithSubcommand() {
 		var flagForSub SubcommandSet
 		for _, scName := range f.SharedSubcommand {
 			subcommand := getSubcommandByName(c.Subcommands, scName)
-			if subcommand.Aliases != nil {
-				flagForSub = append(flagForSub, subcommand.Aliases.ToSlice()...)
-			}
+			flagForSub = append(flagForSub, subcommand.Aliases...)
 		}
 		f.SharedSubcommand = append(f.SharedSubcommand, flagForSub...)
 
@@ -238,7 +229,7 @@ func getSubcommandByName(subcommands Subcommands, subcommandName string) (sub Su
 		if subcommandName == s.Name {
 			return s
 		}
-		if s.Aliases != nil && s.Aliases.Contains(subcommandName) {
+		if slices.Contains(s.Aliases, subcommandName) {
 			return s
 		}
 	}
@@ -261,16 +252,20 @@ func checkSubcommandFunctionIsDefined(c *Cli) {
 }
 
 // checkSubcommandAliasesUniqueness: assert the subcommand Aliases are unique (ie not same alias for two different subcommands), exit otherwise
-func checkSubcommandAliasesUniqueness(c *Cli, allAliases mapset.Set[string]) {
+func checkSubcommandAliasesUniqueness(c *Cli) {
+	seen := map[string]bool{}
 	for _, sub := range c.Subcommands {
-		if sub.Aliases != nil {
-			commonAliases := allAliases.Intersect(sub.Aliases)
-			if commonAliases.Cardinality() == 0 {
-				allAliases.Append(sub.Aliases.ToSlice()...)
+		var duplicates []string
+		for _, a := range sub.Aliases {
+			if seen[a] {
+				duplicates = append(duplicates, a)
 			} else {
-				fmt.Println(QUICLI_ERROR_PREFIX+"subcommand", sub.Name, "define some already defined aliases ('", strings.Join(commonAliases.ToSlice(), ","), "')")
-				os.Exit(2)
+				seen[a] = true
 			}
+		}
+		if len(duplicates) > 0 {
+			fmt.Println(QUICLI_ERROR_PREFIX+"subcommand", sub.Name, "define some already defined aliases ('", strings.Join(duplicates, ","), "')")
+			os.Exit(2)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Remove `github.com/deckarep/golang-set/v2` external dependency
- Replace `mapset.Set[string]` with plain `[]string` for `Subcommand.Aliases`
- `Aliases()` constructor still works identically — callers using `q.Aliases("co", "x")` need no changes
- Set operations (`Contains`, `Intersect`, `ToSlice`) replaced with `slices.Contains` (stdlib) and a simple `map[string]bool`

## Breaking change
`Subcommand.Aliases` field type changed from `mapset.Set[string]` to `[]string`. Code that used mapset methods directly on the field (`.Contains()`, `.ToSlice()`, etc.) must be updated. Code using the `Aliases()` helper is unaffected.

## Test plan
- [x] `go build ./pkg/...` passes
- [x] `go test ./pkg/...` passes
- [x] `go.sum` no longer references `deckarep/golang-set`