### PR TITLE
test: enhance test suite via mutation testing (95%+ efficacy)

### DIFF
--- a/pkg/quicli/completion_test.go
+++ b/pkg/quicli/completion_test.go
@@ -73,3 +73,131 @@ func TestGenerateCompletionUnknownShell(t *testing.T) {
 		t.Error("expected error for unknown shell")
 	}
 }
+
+func hasStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAllFlagNamesWithAndWithoutShort(t *testing.T) {
+	flags := []Flag{
+		{Name: "verbose", Description: "verbose"},
+		{Name: "output", Description: "output", NoShortName: true},
+	}
+	names := allFlagNames(flags)
+	if !hasStr(names, "--verbose") {
+		t.Error("--verbose should be present")
+	}
+	if !hasStr(names, "-v") {
+		t.Error("-v should be present for flag without NoShortName")
+	}
+	if !hasStr(names, "--output") {
+		t.Error("--output should be present")
+	}
+	if hasStr(names, "-o") {
+		t.Error("-o should NOT be present (NoShortName=true)")
+	}
+}
+
+func TestBashCompletionNoSubcommands(t *testing.T) {
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+		Function:    func(Config) {},
+	}
+	script, err := generateCompletion(&cli, "bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(script, "local commands") {
+		t.Error("bash: no subcommands should not have 'local commands'")
+	}
+	if !strings.Contains(script, "--verbose") {
+		t.Error("bash: flags should appear")
+	}
+	if strings.Contains(script, "COMP_CWORD -eq 1") {
+		t.Error("bash: no subcommand branch expected without subcommands")
+	}
+}
+
+func TestZshCompletionNoSubcommands(t *testing.T) {
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+		Function:    func(Config) {},
+	}
+	script, err := generateCompletion(&cli, "zsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(script, "commands=(") {
+		t.Error("zsh: no subcommands should not have commands array")
+	}
+	if strings.Contains(script, "_describe") {
+		t.Error("zsh: no subcommands should not use _describe")
+	}
+	if !strings.Contains(script, "_arguments") {
+		t.Error("zsh: should use _arguments for flags")
+	}
+}
+
+func TestFishCompletionAliases(t *testing.T) {
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Subcommands: Subcommands{
+			{Name: "build", Aliases: Aliases("b"), Description: "build stuff", Function: func(Config) {}},
+		},
+		Flags:    Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+		Function: func(Config) {},
+	}
+	script, err := generateCompletion(&cli, "fish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check for the alias-specific line (contains "(alias)" marker)
+	if !strings.Contains(script, "(alias)") {
+		t.Error("fish: alias should produce '(alias)' marker in completion")
+	}
+}
+
+func TestFishCompletionNoShortName(t *testing.T) {
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose", NoShortName: true}},
+		Function:    func(Config) {},
+	}
+	script, err := generateCompletion(&cli, "fish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "-l verbose") {
+		t.Error("fish: long name should appear")
+	}
+	if strings.Contains(script, "-s v") {
+		t.Error("fish: NoShortName should not produce -s flag")
+	}
+}
+
+func TestFishCompletionWithShortName(t *testing.T) {
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+		Function:    func(Config) {},
+	}
+	script, err := generateCompletion(&cli, "fish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, "-s v") {
+		t.Error("fish: normal flag should produce -s short name")
+	}
+}

--- a/pkg/quicli/envvar_test.go
+++ b/pkg/quicli/envvar_test.go
@@ -14,6 +14,10 @@ func TestEnvVarName(t *testing.T) {
 		{"say-hello", "count", "SAY_HELLO_COUNT"},
 		{"./mycli", "output-format", "MYCLI_OUTPUT_FORMAT"},
 		{"prog", "file", "PROG_FILE"},
+		{"appZ", "flag", "APPZ_FLAG"},   // Z boundary
+		{"app0", "flag", "APP0_FLAG"},   // 0 boundary
+		{"app9", "flag", "APP9_FLAG"},   // 9 boundary
+		{"app09Z", "x", "APP09Z_X"},     // combined boundaries
 	}
 	for _, tc := range cases {
 		if got := envVarName(tc.progName, tc.flagName); got != tc.want {

--- a/pkg/quicli/flag_helpers_test.go
+++ b/pkg/quicli/flag_helpers_test.go
@@ -1,0 +1,103 @@
+package quicli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFlagEnvVarDisplay(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+
+	// Opt-out returns ""
+	if got := flagEnvVarDisplay(Flag{Name: "secret", EnvVar: "-"}); got != "" {
+		t.Errorf("opt-out: got %q, want empty", got)
+	}
+	// Explicit env var
+	if got := flagEnvVarDisplay(Flag{Name: "count", EnvVar: "MY_COUNT"}); got != "MY_COUNT" {
+		t.Errorf("explicit: got %q, want MY_COUNT", got)
+	}
+	// Auto-derived
+	if got := flagEnvVarDisplay(Flag{Name: "count"}); got != "PROG_COUNT" {
+		t.Errorf("auto: got %q, want PROG_COUNT", got)
+	}
+}
+
+func TestGetFlagLineRequired(t *testing.T) {
+	line := getFlagLine(Flag{Name: "output", Description: "out", Default: "", Required: true}, "o", "")
+	if !strings.Contains(line, "(required)") {
+		t.Errorf("required flag should contain '(required)': %s", line)
+	}
+	if strings.Contains(line, "(default:") {
+		t.Errorf("required flag should not show default: %s", line)
+	}
+}
+
+func TestGetFlagLineNotRequired(t *testing.T) {
+	line := getFlagLine(Flag{Name: "count", Description: "count", Default: 5}, "c", "")
+	if strings.Contains(line, "(required)") {
+		t.Errorf("non-required should not contain '(required)': %s", line)
+	}
+	if !strings.Contains(line, "(default:") {
+		t.Errorf("non-required should show default: %s", line)
+	}
+}
+
+func TestGetFlagLineChoices(t *testing.T) {
+	line := getFlagLine(Flag{Name: "format", Description: "fmt", Default: "json", Choices: []string{"json", "yaml"}}, "f", "")
+	if !strings.Contains(line, "(choices: json, yaml)") {
+		t.Errorf("choices should appear: %s", line)
+	}
+}
+
+func TestGetFlagLineNoChoices(t *testing.T) {
+	line := getFlagLine(Flag{Name: "name", Description: "name", Default: "world"}, "n", "")
+	if strings.Contains(line, "(choices:") {
+		t.Errorf("no choices flag should not show choices: %s", line)
+	}
+}
+
+func TestGetFlagLineEnvVar(t *testing.T) {
+	line := getFlagLine(Flag{Name: "name", Description: "name", Default: "world"}, "n", "MY_NAME")
+	if !strings.Contains(line, "[env: MY_NAME]") {
+		t.Errorf("env var should appear: %s", line)
+	}
+}
+
+func TestGetFlagLineShortPresent(t *testing.T) {
+	line := getFlagLine(Flag{Name: "output", Description: "out", Default: ""}, "o", "")
+	if !strings.Contains(line, "-o") {
+		t.Errorf("short name should appear: %s", line)
+	}
+}
+
+func TestGetFlagLineShortAbsent(t *testing.T) {
+	line := getFlagLine(Flag{Name: "output", Description: "out", Default: ""}, "", "")
+	// Without short, format is "--output\t\t\t..."
+	if strings.Contains(line, "\t-o") {
+		t.Errorf("no short name should not show -o: %s", line)
+	}
+}
+
+func TestFormatDefault(t *testing.T) {
+	cases := []struct {
+		val  any
+		want string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{"hello", `"hello"`},
+		{"", `""`},
+		{true, "true"},
+		{false, "false"},
+		{float64(3.14), "3.14"},
+		{float64(0), "0"},
+		{[]string{}, "[]"},
+		{5 * time.Second, "5s"},
+	}
+	for _, tc := range cases {
+		if got := formatDefault(tc.val); got != tc.want {
+			t.Errorf("formatDefault(%v) = %q, want %q", tc.val, got, tc.want)
+		}
+	}
+}

--- a/pkg/quicli/jsonschema_test.go
+++ b/pkg/quicli/jsonschema_test.go
@@ -200,3 +200,167 @@ func TestJSONSchemaSlice(t *testing.T) {
 		t.Errorf("slice type: got %v, want array", prop["type"])
 	}
 }
+
+func TestJSONSchemaPropertyDescription(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 1, Description: "how many"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	if prop["description"] != "how many" {
+		t.Errorf("description: got %v, want 'how many'", prop["description"])
+	}
+}
+
+func TestJSONSchemaNoDescription(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 1, Description: ""}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	if _, ok := prop["description"]; ok {
+		t.Error("empty description should not produce 'description' key")
+	}
+}
+
+func TestJSONSchemaZeroIntDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 0, Description: "count"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	if _, ok := prop["default"]; ok {
+		t.Error("zero int default should not produce 'default' key")
+	}
+}
+
+func TestJSONSchemaNonZeroIntDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 5, Description: "count"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	if prop["default"] != 5 {
+		t.Errorf("non-zero int default: got %v, want 5", prop["default"])
+	}
+}
+
+func TestJSONSchemaZeroStringDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "name", Default: "", Description: "name"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["name"].(map[string]any)
+	if _, ok := prop["default"]; ok {
+		t.Error("empty string default should not produce 'default' key")
+	}
+}
+
+func TestJSONSchemaNonZeroStringDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "name", Default: "world", Description: "name"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["name"].(map[string]any)
+	if prop["default"] != "world" {
+		t.Errorf("non-zero string default: got %v, want world", prop["default"])
+	}
+}
+
+func TestJSONSchemaZeroFloatDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "ratio", Default: float64(0), Description: "ratio"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["ratio"].(map[string]any)
+	if _, ok := prop["default"]; ok {
+		t.Error("zero float default should not produce 'default' key")
+	}
+}
+
+func TestJSONSchemaNonZeroFloatDefault(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "ratio", Default: float64(2.5), Description: "ratio"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["ratio"].(map[string]any)
+	if prop["default"] != float64(2.5) {
+		t.Errorf("non-zero float default: got %v, want 2.5", prop["default"])
+	}
+}
+
+func TestJSONSchemaEnvVarMetadata(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 0, Description: "count"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	ev, ok := prop["x-quicli-env-var"]
+	if !ok {
+		t.Fatal("env var metadata should be present")
+	}
+	if ev != "PROG_COUNT" {
+		t.Errorf("env var: got %v, want PROG_COUNT", ev)
+	}
+}
+
+func TestJSONSchemaEnvVarOptOut(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	cli := Cli{
+		Flags: Flags{{Name: "secret", Default: "", Description: "secret", EnvVar: "-"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["secret"].(map[string]any)
+	if _, ok := prop["x-quicli-env-var"]; ok {
+		t.Error("opted-out env var should not produce metadata")
+	}
+}
+
+func TestJSONSchemaNoFlags(t *testing.T) {
+	cli := Cli{Description: "empty"}
+	schema := cli.JSONSchema()
+	if _, ok := schema["properties"]; ok {
+		t.Error("no flags should not produce 'properties' key")
+	}
+	if _, ok := schema["required"]; ok {
+		t.Error("no flags should not produce 'required' key")
+	}
+}
+
+func TestJSONSchemaNoEnum(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "name", Default: "world", Description: "name"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["name"].(map[string]any)
+	if _, ok := prop["enum"]; ok {
+		t.Error("flag without choices should not have enum")
+	}
+}
+
+func TestJSONSchemaStringNoSubcommands(t *testing.T) {
+	cli := Cli{
+		Description: "test",
+		Flags:       Flags{{Name: "name", Default: "world", Description: "who"}},
+	}
+	s := cli.JSONSchemaString()
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := parsed["x-quicli-subcommands"]; ok {
+		t.Error("no subcommands should not produce x-quicli-subcommands")
+	}
+}

--- a/pkg/quicli/levenshtein_test.go
+++ b/pkg/quicli/levenshtein_test.go
@@ -43,3 +43,36 @@ func TestFindClosestSubcommand(t *testing.T) {
 		t.Errorf("expected empty, got %q", got)
 	}
 }
+
+func TestFindClosestSubcommandDistanceTwoBoundary(t *testing.T) {
+	// levenshtein("dele", "delete") = 2, exactly at maxDist boundary — must match.
+	subs := Subcommands{{Name: "delete"}}
+	if got := findClosestSubcommand(subs, "dele"); got != "delete" {
+		t.Errorf("distance 2 boundary: expected 'delete', got %q", got)
+	}
+}
+
+func TestFindClosestSubcommandDistanceThreeRejects(t *testing.T) {
+	// levenshtein("del", "delete") = 3, beyond maxDist — must NOT match.
+	subs := Subcommands{{Name: "delete"}}
+	if got := findClosestSubcommand(subs, "del"); got != "" {
+		t.Errorf("distance 3: expected empty, got %q", got)
+	}
+}
+
+func TestFindClosestSubcommandFirstMatchWins(t *testing.T) {
+	// "ab" is distance 1 from both "ax" and "ay". First match (by name) wins.
+	subs := Subcommands{{Name: "ax"}, {Name: "ay"}}
+	if got := findClosestSubcommand(subs, "ab"); got != "ax" {
+		t.Errorf("equidistant names: expected 'ax', got %q", got)
+	}
+
+	// Name vs alias equidistant: name match (found first) wins.
+	subs2 := Subcommands{
+		{Name: "ax"},
+		{Name: "other", Aliases: Aliases("az")},
+	}
+	if got := findClosestSubcommand(subs2, "ab"); got != "ax" {
+		t.Errorf("name vs alias equidistant: expected 'ax', got %q", got)
+	}
+}

--- a/pkg/quicli/quicli_test.go
+++ b/pkg/quicli/quicli_test.go
@@ -2,6 +2,8 @@ package quicli
 
 import (
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -92,5 +94,134 @@ func TestParseDoesNotLeakGlobalState(t *testing.T) {
 	cfg2 := cli.Parse()
 	if got := cfg2.GetIntFlag("count"); got != 2 {
 		t.Errorf("second Parse: got %d, want 2", got)
+	}
+}
+
+func TestBoolFlagShortName(t *testing.T) {
+	defer setArgs([]string{"prog", "-v"})()
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+	}
+	cfg := cli.Parse()
+	if !cfg.GetBoolFlag("verbose") {
+		t.Error("bool flag via short -v should be true")
+	}
+}
+
+func TestFloatFlagShortName(t *testing.T) {
+	defer setArgs([]string{"prog", "-r", "2.5"})()
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "ratio", Default: float64(0), Description: "ratio"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetFloatFlag("ratio"); got != 2.5 {
+		t.Errorf("float via short -r: got %f, want 2.5", got)
+	}
+}
+
+func TestStringSliceFlagShortName(t *testing.T) {
+	defer setArgs([]string{"prog", "-f", "a", "-f", "b"})()
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "file", Default: []string{}, Description: "files"}},
+	}
+	cfg := cli.Parse()
+	got := cfg.GetStringSliceFlag("file")
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("slice via short -f: got %v, want [a b]", got)
+	}
+}
+
+func TestDurationFlagShortName(t *testing.T) {
+	defer setArgs([]string{"prog", "-t", "5s"})()
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "timeout", Default: 30 * time.Second, Description: "timeout"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetDurationFlag("timeout"); got != 5*time.Second {
+		t.Errorf("duration via short -t: got %v, want 5s", got)
+	}
+}
+
+func TestValueFlagShortName(t *testing.T) {
+	defer setArgs([]string{"prog", "-l", "warn"})()
+	lv := &testLevel{val: "info"}
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "level", Default: lv, Description: "log level"}},
+	}
+	cfg := cli.Parse()
+	got := cfg.Flags["level"].(*testLevel)
+	if got.val != "warn" {
+		t.Errorf("value via short -l: got %q, want warn", got.val)
+	}
+}
+
+// --- Subprocess tests for CheatSheet / os.Exit paths ---
+
+func TestCheatSheetCSFlagRecognized(t *testing.T) {
+	if os.Getenv("TEST_CS_RECOGNIZED") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [flags]",
+			Description: "test",
+			CheatSheet:  Examples{{Title: "ex", CommandLine: "prog --foo"}},
+		}
+		cli.Parse()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCheatSheetCSFlagRecognized$")
+	cmd.Env = append(os.Environ(), "TEST_CS_RECOGNIZED=1")
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("--cs should be recognized with CheatSheet: %v", err)
+	}
+}
+
+func TestCheatSheetCSFlagNotRegisteredWhenEmpty(t *testing.T) {
+	if os.Getenv("TEST_CS_EMPTY") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [flags]",
+			Description: "test",
+		}
+		cli.Parse()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCheatSheetCSFlagNotRegisteredWhenEmpty$")
+	cmd.Env = append(os.Environ(), "TEST_CS_EMPTY=1")
+	err := cmd.Run()
+	if err == nil {
+		t.Error("--cs should not be recognized without CheatSheet entries")
+	}
+}
+
+func TestCheatSheetPrinted(t *testing.T) {
+	if os.Getenv("TEST_CS_PRINT") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [flags]",
+			Description: "test",
+			CheatSheet:  Examples{{Title: "my-example", CommandLine: "prog --foo"}},
+		}
+		cli.Parse()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCheatSheetPrinted$")
+	cmd.Env = append(os.Environ(), "TEST_CS_PRINT=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v, output: %s", err, out)
+	}
+	if !strings.Contains(string(out), "my-example") {
+		t.Errorf("cheat sheet should be printed, got: %s", out)
 	}
 }

--- a/pkg/quicli/slice_flag_test.go
+++ b/pkg/quicli/slice_flag_test.go
@@ -1,0 +1,26 @@
+package quicli
+
+import "testing"
+
+func TestStringSliceValueString(t *testing.T) {
+	val := []string{"a", "b", "c"}
+	sv := &stringSliceValue{val: &val}
+	if got := sv.String(); got != "a,b,c" {
+		t.Errorf("String() = %q, want 'a,b,c'", got)
+	}
+}
+
+func TestStringSliceValueStringNil(t *testing.T) {
+	sv := &stringSliceValue{val: nil}
+	if got := sv.String(); got != "" {
+		t.Errorf("String() nil = %q, want empty", got)
+	}
+}
+
+func TestStringSliceValueStringEmpty(t *testing.T) {
+	val := []string{}
+	sv := &stringSliceValue{val: &val}
+	if got := sv.String(); got != "" {
+		t.Errorf("String() empty = %q, want empty", got)
+	}
+}

--- a/pkg/quicli/subcommand_test.go
+++ b/pkg/quicli/subcommand_test.go
@@ -1,6 +1,11 @@
 package quicli
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
 
 func TestSubcommandAlias(t *testing.T) {
 	defer setArgs([]string{"prog", "f"})()
@@ -187,5 +192,188 @@ func TestSubcommandExclusiveFlag(t *testing.T) {
 	cli.RunWithSubcommand()
 	if receivedName != "World" {
 		t.Errorf("subcommand Flags: got %q, want World", receivedName)
+	}
+}
+
+func TestSubcommandAmbiguousPrefix(t *testing.T) {
+	// "g" prefixes both "get" and "greet" — ambiguous, no match.
+	sub := getSubcommandByName(
+		Subcommands{
+			{Name: "get", Description: "get", Function: func(Config) {}},
+			{Name: "greet", Description: "greet", Function: func(Config) {}},
+		},
+		"g",
+	)
+	if sub.Name != "" {
+		t.Errorf("ambiguous prefix: expected empty, got %q", sub.Name)
+	}
+}
+
+func TestSubcommandRootWithNoArgs(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	var rootCalled bool
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Function:    func(cfg Config) { rootCalled = true },
+		Subcommands: Subcommands{
+			{Name: "sub", Description: "sub", Function: func(cfg Config) {}},
+		},
+	}
+	cli.RunWithSubcommand()
+	if !rootCalled {
+		t.Error("root function should be called with no args")
+	}
+}
+
+func TestSubcommandRootWithNoArgsAndSubcommandFlag(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	var rootCalled bool
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Function:    func(cfg Config) { rootCalled = true },
+		Flags: Flags{
+			{Name: "since", Default: "", Description: "time range", NotForRootCommand: true, SharedSubcommand: SubcommandSet{"sub"}},
+		},
+		Subcommands: Subcommands{
+			{Name: "sub", Description: "sub", Function: func(cfg Config) {}},
+		},
+	}
+	cli.RunWithSubcommand()
+	if !rootCalled {
+		t.Error("root function should be called with no args and subcommand-only flags")
+	}
+}
+
+func TestRunWithSubcommandRootCommandWithFlags(t *testing.T) {
+	defer setArgs([]string{"prog", "--verbose"})()
+	var gotVerbose bool
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Function:    func(cfg Config) { gotVerbose = cfg.GetBoolFlag("verbose") },
+		Flags:       Flags{{Name: "verbose", Default: false, Description: "verbose"}},
+		Subcommands: Subcommands{
+			{Name: "sub", Description: "sub", Function: func(cfg Config) {}},
+		},
+	}
+	cli.RunWithSubcommand()
+	if !gotVerbose {
+		t.Error("root command with --verbose flag should parse and set verbose to true")
+	}
+}
+
+// --- Subprocess tests for RunWithSubcommand os.Exit paths ---
+
+func TestUsageShowsAvailableCommands(t *testing.T) {
+	if os.Getenv("TEST_AVAIL_CMDS") == "1" {
+		defer setArgs([]string{"prog", "--help"})()
+		cli := Cli{
+			Usage:       "prog [command]",
+			Description: "test",
+			Function:    func(cfg Config) {},
+			Subcommands: Subcommands{
+				{Name: "build", Description: "build it", Function: func(cfg Config) {}},
+			},
+		}
+		cli.RunWithSubcommand()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestUsageShowsAvailableCommands$")
+	cmd.Env = append(os.Environ(), "TEST_AVAIL_CMDS=1")
+	out, _ := cmd.CombinedOutput()
+	if !strings.Contains(string(out), "Available commands:") {
+		t.Errorf("usage should show 'Available commands:', got: %s", out)
+	}
+}
+
+func TestUsageNoAvailableCommandsWithoutSubs(t *testing.T) {
+	if os.Getenv("TEST_NO_AVAIL_CMDS") == "1" {
+		defer setArgs([]string{"prog", "--help"})()
+		cli := Cli{
+			Usage:       "prog [flags]",
+			Description: "test",
+			Function:    func(cfg Config) {},
+		}
+		cli.RunWithSubcommand()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestUsageNoAvailableCommandsWithoutSubs$")
+	cmd.Env = append(os.Environ(), "TEST_NO_AVAIL_CMDS=1")
+	out, _ := cmd.CombinedOutput()
+	if strings.Contains(string(out), "Available commands:") {
+		t.Errorf("usage should NOT show 'Available commands:' without subcommands, got: %s", out)
+	}
+}
+
+func TestRunWithSubcommandCheatSheetCSRecognized(t *testing.T) {
+	if os.Getenv("TEST_SUB_CS") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [command]",
+			Description: "test",
+			Function:    func(cfg Config) {},
+			CheatSheet:  Examples{{Title: "ex", CommandLine: "prog build"}},
+			Subcommands: Subcommands{
+				{Name: "build", Description: "build it", Function: func(cfg Config) {}},
+			},
+		}
+		cli.RunWithSubcommand()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunWithSubcommandCheatSheetCSRecognized$")
+	cmd.Env = append(os.Environ(), "TEST_SUB_CS=1")
+	err := cmd.Run()
+	if err != nil {
+		t.Errorf("--cs should be recognized in RunWithSubcommand with CheatSheet: %v", err)
+	}
+}
+
+func TestRunWithSubcommandCheatSheetCSNotRegisteredWhenEmpty(t *testing.T) {
+	if os.Getenv("TEST_SUB_CS_EMPTY") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [command]",
+			Description: "test",
+			Function:    func(cfg Config) {},
+			Subcommands: Subcommands{
+				{Name: "build", Description: "build it", Function: func(cfg Config) {}},
+			},
+		}
+		cli.RunWithSubcommand()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunWithSubcommandCheatSheetCSNotRegisteredWhenEmpty$")
+	cmd.Env = append(os.Environ(), "TEST_SUB_CS_EMPTY=1")
+	err := cmd.Run()
+	if err == nil {
+		t.Error("--cs should not be recognized without CheatSheet entries in RunWithSubcommand")
+	}
+}
+
+func TestRunWithSubcommandCheatSheetPrinted(t *testing.T) {
+	if os.Getenv("TEST_SUB_CS_PRINT") == "1" {
+		defer setArgs([]string{"prog", "--cs"})()
+		cli := Cli{
+			Usage:       "prog [command]",
+			Description: "test",
+			Function:    func(cfg Config) {},
+			CheatSheet:  Examples{{Title: "sub-example", CommandLine: "prog build"}},
+			Subcommands: Subcommands{
+				{Name: "build", Description: "build it", Function: func(cfg Config) {}},
+			},
+		}
+		cli.RunWithSubcommand()
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunWithSubcommandCheatSheetPrinted$")
+	cmd.Env = append(os.Environ(), "TEST_SUB_CS_PRINT=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v, output: %s", err, out)
+	}
+	if !strings.Contains(string(out), "sub-example") {
+		t.Errorf("cheat sheet should be printed, got: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary

- Enhanced the test suite driven by **gremlins mutation testing**, improving test efficacy from **71.92% to 95.61%**
- Added **+72 killed mutants** (from 146 to 218 killed), reducing survivors from 57 to 10 verified equivalent mutants
- Created 2 new test files and enhanced 6 existing ones, adding ~780 lines of targeted test coverage

## What changed

**New test files:**
- `flag_helpers_test.go` — unit tests for `getFlagLine`, `formatDefault`, `flagEnvVarDisplay`
- `slice_flag_test.go` — unit tests for `stringSliceValue.String()`

**Enhanced tests across:**
- `levenshtein` — boundary distance tests, tie-breaking
- `envvar` — boundary characters (Z, 0, 9)
- `completion` — `NoShortName`, no-subcommands, fish aliases
- `jsonschema` — zero defaults not emitted, description presence, env var metadata
- `quicli` — short-name registration for all flag types (bool/float/slice/duration/value)
- `subcommand` — ambiguous prefix, root-with-no-args, root-with-flags, subprocess tests for `os.Exit` paths

## Remaining 10 survivors

All verified **equivalent mutants** (mutations that don't change observable behavior):
- Boundary mutations on `len > 0` → `>= 0` where iterating empty collections is a no-op
- Parse branch boundaries where both paths produce identical results
- `len(f.Name) > 0` guard where Name is never empty (validated upstream)

## Test plan

- [x] All 115 tests pass (`go test ./pkg/quicli/ -count=1`)
- [x] Gremlins mutation testing confirms 95.61% efficacy
- [x] No source code changes — only test files modified/added

🤖 Generated with [Claude Code](https://claude.com/claude-code)