### PR TITLE
feat: AI-ready features (env-only flags, debug-options, MCP bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,59 +274,82 @@ Programmatic access: `cli.JSONSchema()`, `cli.SubcommandSchemas()`, `cli.JSONSch
 
 ---
 
-### From CLI to MCP server
+### AI agent integration
 
-quicli generates JSON Schema from your flags automatically. This is the foundation for turning any quicli CLI into an [MCP](https://modelcontextprotocol.io/) tool server so AI agents can call your CLI with typed inputs.
+quicli CLIs are AI-ready out of the box. Two approaches depending on your setup:
 
-**Step 1** Build your CLI normally (you already did this):
+#### With MCP (recommended for Claude, Cursor, etc.)
 
-```golang
-type ScanOpts struct {
-    Target string `cli:"target to scan" required:"true"`
-    Port   int    `cli:"port number"    default:"443"`
-}
+Install the bridge:
+```bash
+go install github.com/ariary/quicli/cmd/quicli-mcp@latest
+```
 
-cli := quicli.Cli{
-    Usage:       "scanner [command] [flags]",
-    Description: "Network scanner",
-    Function:    func(cfg quicli.Config) {},
-    Subcommands: quicli.Subcommands{
-        quicli.NewSubcommand("scan", "scan a target", func(o ScanOpts) {
-            fmt.Printf("scanning %s:%d\n", o.Target, o.Port)
-        }),
-    },
+Add to your MCP client config (e.g. `~/.claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "my-tool": {
+      "command": "quicli-mcp",
+      "args": ["/path/to/my-tool"]
+    }
+  }
 }
 ```
 
-**Step 2** Get the schemas for your subcommands:
+That's it. Your CLI's flags become typed tool parameters. Subcommands become separate tools. Env-only flags (`EnvOnly: true`) are passed as environment variables, not CLI args.
 
-```golang
-schemas := cli.SubcommandSchemas()
-// schemas["scan"] → {
-//   "type": "object",
-//   "properties": {
-//     "target": {"type":"string", "description":"target to scan"},
-//     "port":   {"type":"integer", "description":"port number", "default":443}
-//   },
-//   "required": ["target"]
-// }
-```
+#### Without MCP (direct API integration)
 
-Each schema is a valid JSON Schema, exactly what MCP's `tools/list` needs for `inputSchema`, and what OpenAI/Claude function calling needs for `parameters`.
-
-**Step 3** Wire it into an MCP server:
-
-The MCP tool-server protocol is JSON-RPC over stdio. The mapping is:
-
-| MCP method | quicli API |
-|---|---|
-| `tools/list` | `cli.SubcommandSchemas()` -> tool name + inputSchema |
-| `tools/call` | Parse input JSON -> populate flags -> call `Function` |
-
-The schema generation is the hard part, you already have it. The protocol framing is ~200 lines of Go on top.
+Any quicli CLI exposes its contract via `--json-schema`. Feed it to any LLM with tool/function calling:
 
 ```bash
-$ scanner --json-schema   # verify your schemas look right
+# 1. Get the schema
+SCHEMA=$(./my-tool --json-schema)
+
+# 2. Use it as a tool definition in your API call
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -d "{
+    \"model\": \"claude-sonnet-4-20250514\",
+    \"tools\": [{
+      \"name\": \"my-tool\",
+      \"description\": \"$(echo $SCHEMA | jq -r .description)\",
+      \"input_schema\": $SCHEMA
+    }],
+    \"messages\": [{\"role\": \"user\", \"content\": \"...\"}]
+  }"
+
+# 3. When the model calls the tool, run:
+./my-tool --count 5 --name hello
+```
+
+The schema works with Claude API tool_use, OpenAI function calling, or any agent framework that accepts JSON Schema.
+
+#### Env-only flags for secrets
+
+Keep API keys and tokens out of shell history:
+
+```golang
+type Opts struct {
+    Target string `cli:"target to scan" required:"true"`
+    APIKey string `cli:"API key"        env:"only"`
+}
+```
+
+`--help` won't show `APIKey`. `--json-schema` marks it as `"x-quicli-input": "env-only"`. The MCP bridge passes it as an environment variable automatically.
+
+#### Debug your flags
+
+See where each flag's value comes from:
+
+```bash
+$ MYTOOL_NAME=world ./mytool --count 5 --debug-options
+FLAG      VALUE    SOURCE
+--count   5        cli
+--name    world    env (MYTOOL_NAME)
+--format  json     default
+--secret  ***      env (MYTOOL_SECRET)
 ```
 
 ---

--- a/cmd/quicli-mcp/go.mod
+++ b/cmd/quicli-mcp/go.mod
@@ -1,0 +1,3 @@
+module github.com/ariary/quicli/cmd/quicli-mcp
+
+go 1.22

--- a/cmd/quicli-mcp/main.go
+++ b/cmd/quicli-mcp/main.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// parseSchema parses a JSON Schema produced by quicli's --json-schema flag
+// and returns a list of MCP tools. If x-quicli-subcommands exists, each
+// subcommand becomes a separate tool named {binaryName}_{subcommand}.
+// Otherwise the root schema becomes a single tool named {binaryName}.
+func parseSchema(data []byte, binaryName string) ([]mcpTool, error) {
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("invalid JSON schema: %w", err)
+	}
+
+	subcmds, hasSub := schema["x-quicli-subcommands"]
+	if hasSub {
+		subcmdMap, ok := subcmds.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("x-quicli-subcommands is not an object")
+		}
+
+		// Sort subcommand names for deterministic output
+		names := make([]string, 0, len(subcmdMap))
+		for name := range subcmdMap {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		tools := make([]mcpTool, 0, len(names))
+		for _, name := range names {
+			sub := subcmdMap[name]
+			subSchema, ok := sub.(map[string]any)
+			if !ok {
+				continue
+			}
+			desc, _ := subSchema["description"].(string)
+			inputSchema := buildInputSchema(subSchema)
+			tools = append(tools, mcpTool{
+				Name:        binaryName + "_" + name,
+				Description: desc,
+				InputSchema: inputSchema,
+			})
+		}
+		return tools, nil
+	}
+
+	// No subcommands — root becomes a single tool
+	desc, _ := schema["description"].(string)
+	inputSchema := buildInputSchema(schema)
+	return []mcpTool{
+		{
+			Name:        binaryName,
+			Description: desc,
+			InputSchema: inputSchema,
+		},
+	}, nil
+}
+
+// buildInputSchema creates an MCP-compatible input schema from a quicli JSON Schema object.
+func buildInputSchema(schema map[string]any) map[string]any {
+	result := map[string]any{
+		"type": "object",
+	}
+	if props, ok := schema["properties"]; ok {
+		result["properties"] = props
+	}
+	if req, ok := schema["required"]; ok {
+		result["required"] = req
+	}
+	return result
+}
+
+// argsToFlags converts MCP tool call arguments into CLI flags and environment
+// variables. Fields marked with x-quicli-input: "env-only" are placed in
+// envVars using their x-quicli-env-var key. Keys are sorted for deterministic output.
+func argsToFlags(args map[string]any, schema map[string]any) (cliArgs []string, envVars map[string]string) {
+	envVars = make(map[string]string)
+
+	props, _ := schema["properties"].(map[string]any)
+	if props == nil {
+		return nil, envVars
+	}
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val := args[key]
+		propDef, ok := props[key]
+		if !ok {
+			continue
+		}
+		propMap, ok := propDef.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Check if this is an env-only field
+		if input, _ := propMap["x-quicli-input"].(string); input == "env-only" {
+			envKey, _ := propMap["x-quicli-env-var"].(string)
+			if envKey != "" {
+				envVars[envKey] = fmt.Sprintf("%v", val)
+			}
+			continue
+		}
+
+		flag := "--" + key
+
+		switch v := val.(type) {
+		case bool:
+			if v {
+				cliArgs = append(cliArgs, flag)
+			}
+			// false → omit
+		case float64:
+			// Check if it's an integer value
+			if v == float64(int64(v)) {
+				cliArgs = append(cliArgs, flag, strconv.FormatInt(int64(v), 10))
+			} else {
+				cliArgs = append(cliArgs, flag, strconv.FormatFloat(v, 'f', -1, 64))
+			}
+		case []any:
+			for _, item := range v {
+				cliArgs = append(cliArgs, flag, fmt.Sprintf("%v", item))
+			}
+		case string:
+			cliArgs = append(cliArgs, flag, v)
+		default:
+			cliArgs = append(cliArgs, flag, fmt.Sprintf("%v", v))
+		}
+	}
+
+	return cliArgs, envVars
+}
+
+func handleInitialize(req jsonRPCRequest) jsonRPCResponse {
+	return jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo": map[string]any{
+				"name":    "quicli-mcp",
+				"version": "0.1.0",
+			},
+		},
+	}
+}
+
+func handleToolsList(req jsonRPCRequest, tools []mcpTool) jsonRPCResponse {
+	return jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  map[string]any{"tools": tools},
+	}
+}
+
+func handleToolsCall(req jsonRPCRequest, binaryPath string, tools []mcpTool, fullSchema map[string]any) jsonRPCResponse {
+	var params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &rpcError{Code: -32602, Message: "invalid params: " + err.Error()},
+		}
+	}
+
+	// Find matching tool
+	var matched *mcpTool
+	for i := range tools {
+		if tools[i].Name == params.Name {
+			matched = &tools[i]
+			break
+		}
+	}
+	if matched == nil {
+		return jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &rpcError{Code: -32602, Message: "unknown tool: " + params.Name},
+		}
+	}
+
+	// Determine subcommand and schema
+	binaryName := filepath.Base(binaryPath)
+	var subcommand string
+	var toolSchema map[string]any
+
+	prefix := binaryName + "_"
+	if strings.HasPrefix(params.Name, prefix) {
+		subcommand = strings.TrimPrefix(params.Name, prefix)
+		// Get subcommand schema from fullSchema
+		if subcmds, ok := fullSchema["x-quicli-subcommands"].(map[string]any); ok {
+			if subSchema, ok := subcmds[subcommand].(map[string]any); ok {
+				toolSchema = subSchema
+			}
+		}
+	} else {
+		// Root tool
+		toolSchema = fullSchema
+	}
+
+	if toolSchema == nil {
+		toolSchema = map[string]any{}
+	}
+
+	// Convert arguments to flags
+	cliArgs, envVars := argsToFlags(params.Arguments, toolSchema)
+
+	// Build command arguments
+	var cmdArgs []string
+	if subcommand != "" {
+		cmdArgs = append(cmdArgs, subcommand)
+	}
+	cmdArgs = append(cmdArgs, cliArgs...)
+
+	// Execute the command
+	cmd := exec.Command(binaryPath, cmdArgs...)
+	cmd.Env = os.Environ()
+	for k, v := range envVars {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	output, err := cmd.CombinedOutput()
+
+	result := map[string]any{
+		"content": []mcpContent{
+			{Type: "text", Text: string(output)},
+		},
+	}
+
+	if err != nil {
+		result["isError"] = true
+	}
+
+	return jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	}
+}
+
+func writeResponse(resp jsonRPCResponse) {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshaling response: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: quicli-mcp <binary>")
+		os.Exit(1)
+	}
+
+	binaryPath := os.Args[1]
+
+	// Run <binary> --json-schema to discover the CLI contract
+	cmd := exec.Command(binaryPath, "--json-schema")
+	schemaOutput, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running %s --json-schema: %v\n", binaryPath, err)
+		os.Exit(1)
+	}
+
+	binaryName := filepath.Base(binaryPath)
+
+	tools, err := parseSchema(schemaOutput, binaryName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse the full schema for use in tools/call handler
+	var fullSchema map[string]any
+	if err := json.Unmarshal(schemaOutput, &fullSchema); err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing full schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Enter stdin loop — read one JSON object per line
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB buffer
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		var req jsonRPCRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			writeResponse(jsonRPCResponse{
+				JSONRPC: "2.0",
+				Error:   &rpcError{Code: -32700, Message: "parse error: " + err.Error()},
+			})
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			writeResponse(handleInitialize(req))
+		case "notifications/initialized":
+			// Silent — no response for notifications
+		case "tools/list":
+			writeResponse(handleToolsList(req, tools))
+		case "tools/call":
+			writeResponse(handleToolsCall(req, binaryPath, tools, fullSchema))
+		default:
+			writeResponse(jsonRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error:   &rpcError{Code: -32601, Message: "method not found: " + req.Method},
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading stdin: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/quicli-mcp/main_test.go
+++ b/cmd/quicli-mcp/main_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseSchemaRootOnly(t *testing.T) {
+	raw := `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"description": "A test tool",
+		"properties": {
+			"count": {"type": "integer", "description": "how many", "default": 1},
+			"name": {"type": "string", "description": "a name"}
+		},
+		"required": ["name"]
+	}`
+	tools, err := parseSchema([]byte(raw), "mytool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "mytool" {
+		t.Errorf("name: got %q, want mytool", tools[0].Name)
+	}
+	if tools[0].Description != "A test tool" {
+		t.Errorf("description: got %q", tools[0].Description)
+	}
+}
+
+func TestParseSchemaWithSubcommands(t *testing.T) {
+	raw := `{
+		"type": "object",
+		"description": "A tool",
+		"x-quicli-subcommands": {
+			"scan": {
+				"type": "object",
+				"description": "scan a target",
+				"properties": {"target": {"type": "string"}},
+				"required": ["target"]
+			},
+			"list": {
+				"type": "object",
+				"description": "list results"
+			}
+		}
+	}`
+	tools, err := parseSchema([]byte(raw), "scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	if !names["scanner_scan"] {
+		t.Error("missing scanner_scan")
+	}
+	if !names["scanner_list"] {
+		t.Error("missing scanner_list")
+	}
+}
+
+func TestArgsToFlags(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"count":   map[string]any{"type": "integer"},
+			"name":    map[string]any{"type": "string"},
+			"verbose": map[string]any{"type": "boolean"},
+			"tags":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			"secret":  map[string]any{"type": "string", "x-quicli-input": "env-only", "x-quicli-env-var": "MY_SECRET"},
+		},
+	}
+	args := map[string]any{
+		"count":   float64(5),
+		"name":    "hello",
+		"verbose": true,
+		"tags":    []any{"a", "b"},
+		"secret":  "token123",
+	}
+	cliArgs, envVars := argsToFlags(args, schema)
+
+	// Check env-only goes to envVars
+	if envVars["MY_SECRET"] != "token123" {
+		t.Errorf("env var: got %q, want token123", envVars["MY_SECRET"])
+	}
+
+	// Check CLI args contain expected flags (order is sorted by key)
+	// count, name, tags, verbose (alphabetical, secret excluded)
+	expectedContains := map[string]bool{"--count": true, "5": true, "--name": true, "hello": true, "--verbose": true, "--tags": true, "a": true, "b": true}
+	for _, a := range cliArgs {
+		delete(expectedContains, a)
+	}
+	if len(expectedContains) > 0 {
+		t.Errorf("missing in cliArgs: %v, got: %v", expectedContains, cliArgs)
+	}
+
+	// secret should NOT be in cliArgs
+	for _, a := range cliArgs {
+		if a == "--secret" || a == "token123" {
+			t.Errorf("env-only flag should not be in cliArgs: %v", cliArgs)
+		}
+	}
+}
+
+func TestArgsToFlagsIntegerFormatting(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"port": map[string]any{"type": "integer"},
+		},
+	}
+	args := map[string]any{"port": float64(8080)}
+	cliArgs, _ := argsToFlags(args, schema)
+	found := false
+	for i, a := range cliArgs {
+		if a == "--port" && i+1 < len(cliArgs) {
+			if cliArgs[i+1] != "8080" {
+				t.Errorf("port value: got %q, want 8080", cliArgs[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("--port not found")
+	}
+}
+
+func TestArgsToFlagsBoolFalseOmitted(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"verbose": map[string]any{"type": "boolean"},
+		},
+	}
+	args := map[string]any{"verbose": false}
+	cliArgs, _ := argsToFlags(args, schema)
+	if len(cliArgs) != 0 {
+		t.Errorf("false boolean should produce no args, got %v", cliArgs)
+	}
+}
+
+func TestHandleInitialize(t *testing.T) {
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	}
+	resp := handleInitialize(req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+}
+
+func TestHandleToolsList(t *testing.T) {
+	tools := []mcpTool{
+		{Name: "test", Description: "a test", InputSchema: map[string]any{"type": "object"}},
+	}
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	}
+	resp := handleToolsList(req, tools)
+	if resp.Error != nil {
+		t.Fatal("unexpected error")
+	}
+}
+
+func TestParseSchemaInvalidJSON(t *testing.T) {
+	_, err := parseSchema([]byte("not json"), "test")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}

--- a/cmd/quicli-mcp/main_test.go
+++ b/cmd/quicli-mcp/main_test.go
@@ -180,3 +180,489 @@ func TestParseSchemaInvalidJSON(t *testing.T) {
 		t.Error("expected error for invalid JSON")
 	}
 }
+
+// --- Task 9: Edge Case Tests ---
+
+func TestArgsToFlagsEmptyArgs(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	args := map[string]any{}
+	cliArgs, envVars := argsToFlags(args, schema)
+	if len(cliArgs) != 0 {
+		t.Errorf("expected no cliArgs, got %v", cliArgs)
+	}
+	if len(envVars) != 0 {
+		t.Errorf("expected no envVars, got %v", envVars)
+	}
+}
+
+func TestArgsToFlagsNilProperties(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+	}
+	args := map[string]any{"foo": "bar"}
+	cliArgs, envVars := argsToFlags(args, schema)
+	if cliArgs != nil {
+		t.Errorf("expected nil cliArgs for nil properties, got %v", cliArgs)
+	}
+	if len(envVars) != 0 {
+		t.Errorf("expected no envVars, got %v", envVars)
+	}
+}
+
+func TestArgsToFlagsUnknownArgIgnored(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	args := map[string]any{
+		"name":    "hello",
+		"unknown": "ignored",
+	}
+	cliArgs, _ := argsToFlags(args, schema)
+	for _, a := range cliArgs {
+		if a == "--unknown" || a == "ignored" {
+			t.Errorf("unknown arg should be ignored, got %v", cliArgs)
+		}
+	}
+	if len(cliArgs) != 2 {
+		t.Errorf("expected 2 cliArgs (--name hello), got %v", cliArgs)
+	}
+}
+
+func TestArgsToFlagsFloatNonInteger(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"rate": map[string]any{"type": "number"},
+		},
+	}
+	args := map[string]any{"rate": float64(3.14)}
+	cliArgs, _ := argsToFlags(args, schema)
+	found := false
+	for i, a := range cliArgs {
+		if a == "--rate" && i+1 < len(cliArgs) {
+			if cliArgs[i+1] != "3.14" {
+				t.Errorf("rate value: got %q, want 3.14", cliArgs[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("--rate not found in cliArgs")
+	}
+}
+
+func TestArgsToFlagsEmptyArray(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+	}
+	args := map[string]any{"tags": []any{}}
+	cliArgs, _ := argsToFlags(args, schema)
+	if len(cliArgs) != 0 {
+		t.Errorf("empty array should produce no args, got %v", cliArgs)
+	}
+}
+
+func TestArgsToFlagsEmptyString(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	args := map[string]any{"name": ""}
+	cliArgs, _ := argsToFlags(args, schema)
+	if len(cliArgs) != 2 || cliArgs[0] != "--name" || cliArgs[1] != "" {
+		t.Errorf("empty string should produce --name '', got %v", cliArgs)
+	}
+}
+
+func TestArgsToFlagsEnvOnlyWithoutEnvVar(t *testing.T) {
+	// env-only field without x-quicli-env-var should be silently ignored
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"secret": map[string]any{"type": "string", "x-quicli-input": "env-only"},
+		},
+	}
+	args := map[string]any{"secret": "value"}
+	cliArgs, envVars := argsToFlags(args, schema)
+	if len(cliArgs) != 0 {
+		t.Errorf("env-only should not produce cliArgs, got %v", cliArgs)
+	}
+	if len(envVars) != 0 {
+		t.Errorf("missing env-var key should not produce envVars, got %v", envVars)
+	}
+}
+
+func TestParseSchemaSubcommandsSorted(t *testing.T) {
+	raw := `{
+		"type": "object",
+		"x-quicli-subcommands": {
+			"zeta": {"type": "object", "description": "z"},
+			"alpha": {"type": "object", "description": "a"},
+			"middle": {"type": "object", "description": "m"}
+		}
+	}`
+	tools, err := parseSchema([]byte(raw), "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+	expectedOrder := []string{"app_alpha", "app_middle", "app_zeta"}
+	for i, tool := range tools {
+		if tool.Name != expectedOrder[i] {
+			t.Errorf("tool[%d]: got %q, want %q", i, tool.Name, expectedOrder[i])
+		}
+	}
+}
+
+func TestParseSchemaNoDescription(t *testing.T) {
+	raw := `{"type": "object"}`
+	tools, err := parseSchema([]byte(raw), "bare")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Description != "" {
+		t.Errorf("expected empty description, got %q", tools[0].Description)
+	}
+}
+
+func TestParseSchemaNoProperties(t *testing.T) {
+	raw := `{"type": "object", "description": "minimal"}`
+	tools, err := parseSchema([]byte(raw), "min")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	// inputSchema should still have "type": "object" but no "properties" key
+	if tools[0].InputSchema["type"] != "object" {
+		t.Error("expected type object in inputSchema")
+	}
+	if _, has := tools[0].InputSchema["properties"]; has {
+		t.Error("expected no properties key in inputSchema")
+	}
+}
+
+func TestParseSchemaPreservesRequired(t *testing.T) {
+	raw := `{
+		"type": "object",
+		"description": "tool",
+		"properties": {"name": {"type": "string"}},
+		"required": ["name"]
+	}`
+	tools, err := parseSchema([]byte(raw), "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, ok := tools[0].InputSchema["required"].([]any)
+	if !ok {
+		t.Fatal("required field missing or wrong type")
+	}
+	if len(req) != 1 || req[0] != "name" {
+		t.Errorf("expected required [name], got %v", req)
+	}
+}
+
+func TestHandleInitializeProtocolVersion(t *testing.T) {
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`"abc"`),
+		Method:  "initialize",
+	}
+	resp := handleInitialize(req)
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	if result["protocolVersion"] != "2024-11-05" {
+		t.Errorf("protocol version: got %v", result["protocolVersion"])
+	}
+	info, ok := result["serverInfo"].(map[string]any)
+	if !ok {
+		t.Fatal("serverInfo is not a map")
+	}
+	if info["name"] != "quicli-mcp" {
+		t.Errorf("server name: got %v", info["name"])
+	}
+	if info["version"] != "0.1.0" {
+		t.Errorf("server version: got %v", info["version"])
+	}
+	// ID should be preserved (string ID)
+	if string(resp.ID) != `"abc"` {
+		t.Errorf("ID: got %s, want \"abc\"", resp.ID)
+	}
+}
+
+func TestHandleToolsCallUnknownTool(t *testing.T) {
+	tools := []mcpTool{
+		{Name: "app_scan", Description: "scan"},
+	}
+	fullSchema := map[string]any{}
+	params, _ := json.Marshal(map[string]any{
+		"name":      "app_nonexistent",
+		"arguments": map[string]any{},
+	})
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`3`),
+		Method:  "tools/call",
+		Params:  params,
+	}
+	resp := handleToolsCall(req, "/usr/bin/app", tools, fullSchema)
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code: got %d, want -32602", resp.Error.Code)
+	}
+}
+
+func TestHandleToolsCallInvalidParams(t *testing.T) {
+	tools := []mcpTool{}
+	fullSchema := map[string]any{}
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`4`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`not valid json`),
+	}
+	resp := handleToolsCall(req, "/usr/bin/app", tools, fullSchema)
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid params")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("error code: got %d, want -32602", resp.Error.Code)
+	}
+}
+
+func TestHandleToolsCallExecutesBinary(t *testing.T) {
+	// Use echo as a real binary to test actual execution
+	tools := []mcpTool{
+		{Name: "echo", Description: "echo", InputSchema: map[string]any{"type": "object"}},
+	}
+	fullSchema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}
+	params, _ := json.Marshal(map[string]any{
+		"name":      "echo",
+		"arguments": map[string]any{},
+	})
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`5`),
+		Method:  "tools/call",
+		Params:  params,
+	}
+	resp := handleToolsCall(req, "/bin/echo", tools, fullSchema)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	// isError should not be set for successful execution
+	if _, has := result["isError"]; has {
+		t.Error("isError should not be set for successful command")
+	}
+}
+
+func TestHandleToolsCallNonZeroExit(t *testing.T) {
+	// Use 'false' command which always exits with code 1
+	tools := []mcpTool{
+		{Name: "false", Description: "always fails", InputSchema: map[string]any{"type": "object"}},
+	}
+	fullSchema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}
+	params, _ := json.Marshal(map[string]any{
+		"name":      "false",
+		"arguments": map[string]any{},
+	})
+	req := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`6`),
+		Method:  "tools/call",
+		Params:  params,
+	}
+	resp := handleToolsCall(req, "/usr/bin/false", tools, fullSchema)
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	isErr, has := result["isError"]
+	if !has {
+		t.Fatal("isError should be set for failed command")
+	}
+	if isErr != true {
+		t.Errorf("isError: got %v, want true", isErr)
+	}
+}
+
+func TestWriteResponseJSON(t *testing.T) {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  map[string]any{"ok": true},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["jsonrpc"] != "2.0" {
+		t.Errorf("jsonrpc: got %v", parsed["jsonrpc"])
+	}
+	// Error should be omitted when nil
+	if _, has := parsed["error"]; has {
+		t.Error("error field should be omitted when nil")
+	}
+}
+
+func TestWriteResponseErrorOmitsResult(t *testing.T) {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Error:   &rpcError{Code: -32601, Message: "not found"},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if _, has := parsed["result"]; has {
+		t.Error("result field should be omitted when nil")
+	}
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		t.Fatal("error is not an object")
+	}
+	if errObj["code"].(float64) != -32601 {
+		t.Errorf("error code: got %v", errObj["code"])
+	}
+}
+
+func TestArgsToFlagsSortOrder(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"zebra": map[string]any{"type": "string"},
+			"alpha": map[string]any{"type": "string"},
+			"mid":   map[string]any{"type": "string"},
+		},
+	}
+	args := map[string]any{
+		"zebra": "z",
+		"alpha": "a",
+		"mid":   "m",
+	}
+	cliArgs, _ := argsToFlags(args, schema)
+	// Should be sorted: alpha, mid, zebra
+	expected := []string{"--alpha", "a", "--mid", "m", "--zebra", "z"}
+	if len(cliArgs) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(cliArgs), cliArgs)
+	}
+	for i, e := range expected {
+		if cliArgs[i] != e {
+			t.Errorf("cliArgs[%d]: got %q, want %q", i, cliArgs[i], e)
+		}
+	}
+}
+
+func TestArgsToFlagsLargeInteger(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"big": map[string]any{"type": "integer"},
+		},
+	}
+	args := map[string]any{"big": float64(1000000000)}
+	cliArgs, _ := argsToFlags(args, schema)
+	found := false
+	for i, a := range cliArgs {
+		if a == "--big" && i+1 < len(cliArgs) {
+			if cliArgs[i+1] != "1000000000" {
+				t.Errorf("big value: got %q, want 1000000000", cliArgs[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("--big not found")
+	}
+}
+
+func TestArgsToFlagsZeroInteger(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"count": map[string]any{"type": "integer"},
+		},
+	}
+	args := map[string]any{"count": float64(0)}
+	cliArgs, _ := argsToFlags(args, schema)
+	found := false
+	for i, a := range cliArgs {
+		if a == "--count" && i+1 < len(cliArgs) {
+			if cliArgs[i+1] != "0" {
+				t.Errorf("count value: got %q, want 0", cliArgs[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("--count not found")
+	}
+}
+
+func TestArgsToFlagsNegativeInteger(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"offset": map[string]any{"type": "integer"},
+		},
+	}
+	args := map[string]any{"offset": float64(-10)}
+	cliArgs, _ := argsToFlags(args, schema)
+	found := false
+	for i, a := range cliArgs {
+		if a == "--offset" && i+1 < len(cliArgs) {
+			if cliArgs[i+1] != "-10" {
+				t.Errorf("offset value: got %q, want -10", cliArgs[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("--offset not found")
+	}
+}

--- a/pkg/quicli/completion.go
+++ b/pkg/quicli/completion.go
@@ -40,6 +40,9 @@ func allFlagNames(flags []Flag) []string {
 	var names []string
 	seen := map[string]bool{}
 	for _, f := range flags {
+		if f.EnvOnly {
+			continue
+		}
 		names = append(names, "--"+f.Name)
 		short := f.ShortName
 		if short == "" {

--- a/pkg/quicli/completion_test.go
+++ b/pkg/quicli/completion_test.go
@@ -201,3 +201,19 @@ func TestFishCompletionWithShortName(t *testing.T) {
 		t.Error("fish: normal flag should produce -s short name")
 	}
 }
+
+func TestAllFlagNamesSkipsEnvOnly(t *testing.T) {
+	flags := []Flag{
+		{Name: "output", Default: "", Description: "output file"},
+		{Name: "secret", Default: "", Description: "API secret", EnvOnly: true},
+	}
+	names := allFlagNames(flags)
+	for _, n := range names {
+		if strings.Contains(n, "secret") {
+			t.Errorf("env-only flag should not appear in completion: %v", names)
+		}
+	}
+	if len(names) != 2 {
+		t.Errorf("expected 2 entries (--output, -o), got %d: %v", len(names), names)
+	}
+}

--- a/pkg/quicli/debug.go
+++ b/pkg/quicli/debug.go
@@ -1,0 +1,114 @@
+package quicli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+// buildSourceMap determines where each flag's value came from.
+// cliSet contains flag names explicitly set on the command line (snapshot from
+// fs.Visit after fs.Parse, before applyEnvVars). Flags set in fs after that
+// (via applyEnvVars calling fs.Set) came from env vars.
+func buildSourceMap(flags []Flag, fs *flag.FlagSet, cliSet map[string]bool) map[string]string {
+	allSet := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		allSet[f.Name] = true
+	})
+
+	sm := make(map[string]string, len(flags))
+	for _, f := range flags {
+		if f.EnvOnly {
+			sm[f.Name] = "default"
+			continue
+		}
+		if cliSet[f.Name] {
+			sm[f.Name] = "cli"
+		} else if allSet[f.Name] {
+			sm[f.Name] = "env"
+		} else {
+			sm[f.Name] = "default"
+		}
+	}
+	return sm
+}
+
+// flagValue returns the string representation of a flag's current value from config.
+func flagValue(f Flag, cfg Config) string {
+	v, ok := cfg.Flags[f.Name]
+	if !ok {
+		return formatDefault(f.Default)
+	}
+	switch ptr := v.(type) {
+	case *int:
+		return fmt.Sprintf("%d", *ptr)
+	case *string:
+		return *ptr
+	case *bool:
+		return fmt.Sprintf("%v", *ptr)
+	case *float64:
+		return fmt.Sprintf("%g", *ptr)
+	case *stringSliceValue:
+		return ptr.String()
+	default:
+		if fv, ok := v.(flag.Value); ok {
+			return fv.String()
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+// formatDebugTable returns a formatted table of flag names, values, and sources.
+// Env-only flag values are masked as "***".
+func formatDebugTable(flags []Flag, values map[string]string, sources map[string]string) string {
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 2, 8, 2, ' ', 0)
+	fmt.Fprintf(w, "FLAG\tVALUE\tSOURCE\n")
+	for _, f := range flags {
+		val := values[f.Name]
+		if f.EnvOnly {
+			val = "***"
+		}
+		src := sources[f.Name]
+		fmt.Fprintf(w, "--%s\t%s\t%s\n", f.Name, val, src)
+	}
+	w.Flush()
+	return b.String()
+}
+
+// printDebugOptions collects values and sources, then prints the debug table and exits.
+func printDebugOptions(flags []Flag, cfg Config, sources map[string]string) {
+	values := make(map[string]string, len(flags))
+	for _, f := range flags {
+		values[f.Name] = flagValue(f, cfg)
+	}
+
+	// Enrich env-only sources with actual env var name.
+	for _, f := range flags {
+		if !f.EnvOnly {
+			continue
+		}
+		envKey := f.EnvVar
+		if envKey == "" {
+			envKey = envVarName(os.Args[0], f.Name)
+		}
+		if _, ok := os.LookupEnv(envKey); ok {
+			sources[f.Name] = "env (" + envKey + ")"
+		}
+	}
+
+	// Enrich regular env sources with the env var name.
+	for _, f := range flags {
+		if sources[f.Name] == "env" {
+			envKey := flagEnvVarDisplay(f)
+			if envKey != "" {
+				sources[f.Name] = "env (" + envKey + ")"
+			}
+		}
+	}
+
+	fmt.Print(formatDebugTable(flags, values, sources))
+	os.Exit(0)
+}

--- a/pkg/quicli/debug_test.go
+++ b/pkg/quicli/debug_test.go
@@ -79,3 +79,26 @@ func TestFormatDebugTable(t *testing.T) {
 		t.Error("table should show source")
 	}
 }
+
+func TestDebugOptionsValuesCorrect(t *testing.T) {
+	defer setArgs([]string{"prog", "--count", "5"})()
+	t.Setenv("PROG_NAME", "from-env")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags: Flags{
+			{Name: "count", Default: 0, Description: "count"},
+			{Name: "name", Default: "default", Description: "name"},
+			{Name: "secret", Default: "", Description: "secret", EnvOnly: true},
+		},
+	}
+	cfg := cli.Parse()
+
+	if got := cfg.GetIntFlag("count"); got != 5 {
+		t.Errorf("count: got %d, want 5", got)
+	}
+	if got := cfg.GetStringFlag("name"); got != "from-env" {
+		t.Errorf("name: got %q, want from-env", got)
+	}
+}

--- a/pkg/quicli/debug_test.go
+++ b/pkg/quicli/debug_test.go
@@ -1,0 +1,81 @@
+package quicli
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestBuildSourceMapCLI(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("output", "", "output file")
+	fs.Parse([]string{"--output", "out.txt"})
+
+	flags := []Flag{{Name: "output", Default: "", Description: "output file"}}
+	sm := buildSourceMap(flags, fs, map[string]bool{"output": true})
+	if sm["output"] != "cli" {
+		t.Errorf("output source: got %q, want cli", sm["output"])
+	}
+}
+
+func TestBuildSourceMapEnv(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("output", "", "output file")
+	fs.Parse([]string{})
+	fs.Set("output", "from-env")
+
+	flags := []Flag{{Name: "output", Default: "", Description: "output file"}}
+	sm := buildSourceMap(flags, fs, map[string]bool{})
+	if sm["output"] != "env" {
+		t.Errorf("output source: got %q, want env", sm["output"])
+	}
+}
+
+func TestBuildSourceMapDefault(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("output", "default.txt", "output file")
+	fs.Parse([]string{})
+
+	flags := []Flag{{Name: "output", Default: "default.txt", Description: "output file"}}
+	sm := buildSourceMap(flags, fs, map[string]bool{})
+	if sm["output"] != "default" {
+		t.Errorf("output source: got %q, want default", sm["output"])
+	}
+}
+
+func TestBuildSourceMapEnvOnly(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Parse([]string{})
+
+	flags := []Flag{{Name: "secret", Default: "", Description: "secret", EnvOnly: true}}
+	sm := buildSourceMap(flags, fs, map[string]bool{})
+	if sm["secret"] != "default" {
+		t.Errorf("secret source: got %q, want default", sm["secret"])
+	}
+}
+
+func TestFormatDebugTable(t *testing.T) {
+	flags := []Flag{
+		{Name: "output", Default: "", Description: "output file"},
+		{Name: "secret", Default: "", Description: "secret", EnvOnly: true},
+	}
+	values := map[string]string{"output": "out.txt", "secret": "s3cret"}
+	sources := map[string]string{"output": "cli", "secret": "env (MY_SECRET)"}
+
+	table := formatDebugTable(flags, values, sources)
+	if !strings.Contains(table, "output") {
+		t.Error("table should contain output flag")
+	}
+	if !strings.Contains(table, "out.txt") {
+		t.Error("table should contain output value")
+	}
+	if !strings.Contains(table, "***") {
+		t.Error("env-only values should be masked")
+	}
+	if strings.Contains(table, "s3cret") {
+		t.Error("env-only value should NOT appear in plain text")
+	}
+	if !strings.Contains(table, "cli") {
+		t.Error("table should show source")
+	}
+}

--- a/pkg/quicli/envvar.go
+++ b/pkg/quicli/envvar.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // envVarName derives the auto env var name from program name and flag name.
@@ -36,6 +38,9 @@ func applyEnvVars(flags []Flag, fs *flag.FlagSet) {
 	})
 
 	for _, f := range flags {
+		if f.EnvOnly {
+			continue // handled by applyEnvOnlyFlags
+		}
 		if cliProvided[f.Name] {
 			continue
 		}
@@ -55,6 +60,93 @@ func applyEnvVars(flags []Flag, fs *flag.FlagSet) {
 		if err := fs.Set(f.Name, val); err != nil {
 			fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for flag --%s: %v\n", envKey, val, f.Name, err)
 			os.Exit(1)
+		}
+	}
+}
+
+// applyEnvOnlyFlags populates config.Flags for flags marked EnvOnly.
+// These flags are never registered in the flag.FlagSet; their values come
+// exclusively from environment variables (or the default).
+func applyEnvOnlyFlags(flags []Flag, cfg Config) {
+	for _, f := range flags {
+		if !f.EnvOnly {
+			continue
+		}
+
+		// Determine the env var key to check.
+		envKey := f.EnvVar
+		if envKey == "" {
+			envKey = envVarName(os.Args[0], f.Name)
+		}
+		envVal, envSet := os.LookupEnv(envKey)
+
+		// Ensure Default is not nil (same as Parse does for regular flags).
+		def := f.Default
+		if def == nil {
+			def = false
+		}
+
+		switch def.(type) {
+		case string:
+			v := def.(string)
+			if envSet {
+				v = envVal
+			}
+			cfg.Flags[f.Name] = &v
+		case int:
+			v := def.(int)
+			if envSet {
+				parsed, err := strconv.Atoi(envVal)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for env-only flag %q (int): %v\n", envKey, envVal, f.Name, err)
+					os.Exit(1)
+				}
+				v = parsed
+			}
+			cfg.Flags[f.Name] = &v
+		case bool:
+			v := def.(bool)
+			if envSet {
+				parsed, err := strconv.ParseBool(envVal)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for env-only flag %q (bool): %v\n", envKey, envVal, f.Name, err)
+					os.Exit(1)
+				}
+				v = parsed
+			}
+			cfg.Flags[f.Name] = &v
+		case float64:
+			v := def.(float64)
+			if envSet {
+				parsed, err := strconv.ParseFloat(envVal, 64)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for env-only flag %q (float64): %v\n", envKey, envVal, f.Name, err)
+					os.Exit(1)
+				}
+				v = parsed
+			}
+			cfg.Flags[f.Name] = &v
+		case time.Duration:
+			v := def.(time.Duration)
+			if envSet {
+				parsed, err := time.ParseDuration(envVal)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"env var %s=%q invalid for env-only flag %q (duration): %v\n", envKey, envVal, f.Name, err)
+					os.Exit(1)
+				}
+				v = parsed
+			}
+			cfg.Flags[f.Name] = &v
+		case []string:
+			v := def.([]string)
+			if envSet {
+				v = strings.Split(envVal, ",")
+			}
+			sv := &stringSliceValue{val: &v}
+			cfg.Flags[f.Name] = sv
+		default:
+			fmt.Fprintf(os.Stderr, QUICLI_ERROR_PREFIX+"unsupported type for env-only flag %q\n", f.Name)
+			os.Exit(2)
 		}
 	}
 }

--- a/pkg/quicli/envvar_test.go
+++ b/pkg/quicli/envvar_test.go
@@ -89,3 +89,78 @@ func TestApplyEnvVarCLIOverridesEnv(t *testing.T) {
 		t.Errorf("CLI should override env var: got %d, want 3", got)
 	}
 }
+
+func TestEnvOnlyFlagResolved(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("PROG_SECRET", "s3cret")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "secret", Default: "", Description: "a secret", EnvOnly: true}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetStringFlag("secret"); got != "s3cret" {
+		t.Errorf("env-only string flag: got %q, want %q", got, "s3cret")
+	}
+}
+
+func TestEnvOnlyFlagWithExplicitEnvVar(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("MY_SECRET", "token123")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "secret", Default: "", Description: "a secret", EnvOnly: true, EnvVar: "MY_SECRET"}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetStringFlag("secret"); got != "token123" {
+		t.Errorf("env-only explicit env var: got %q, want %q", got, "token123")
+	}
+}
+
+func TestEnvOnlyFlagDefault(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	// No env var set — should use default value.
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "secret", Default: "fallback", Description: "a secret", EnvOnly: true}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetStringFlag("secret"); got != "fallback" {
+		t.Errorf("env-only default: got %q, want %q", got, "fallback")
+	}
+}
+
+func TestEnvOnlyFlagIntType(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("PROG_PORT", "9090")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "port", Default: 8080, Description: "port", EnvOnly: true}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetIntFlag("port"); got != 9090 {
+		t.Errorf("env-only int flag: got %d, want 9090", got)
+	}
+}
+
+func TestEnvOnlyFlagBoolType(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("PROG_DEBUG", "true")
+
+	cli := Cli{
+		Usage:       "prog [flags]",
+		Description: "test",
+		Flags:       Flags{{Name: "debug", Default: false, Description: "debug mode", EnvOnly: true}},
+	}
+	cfg := cli.Parse()
+	if got := cfg.GetBoolFlag("debug"); got != true {
+		t.Errorf("env-only bool flag: got %v, want true", got)
+	}
+}

--- a/pkg/quicli/jsonschema.go
+++ b/pkg/quicli/jsonschema.go
@@ -139,5 +139,9 @@ func flagToSchemaProperty(f Flag) map[string]any {
 		prop["x-quicli-env-var"] = ev
 	}
 
+	if f.EnvOnly {
+		prop["x-quicli-input"] = "env-only"
+	}
+
 	return prop
 }

--- a/pkg/quicli/jsonschema_test.go
+++ b/pkg/quicli/jsonschema_test.go
@@ -364,3 +364,32 @@ func TestJSONSchemaStringNoSubcommands(t *testing.T) {
 		t.Error("no subcommands should not produce x-quicli-subcommands")
 	}
 }
+
+func TestJSONSchemaEnvOnlyMarker(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	cli := Cli{
+		Flags: Flags{{Name: "secret", Default: "", Description: "API secret", EnvOnly: true}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["secret"].(map[string]any)
+	input, ok := prop["x-quicli-input"]
+	if !ok {
+		t.Fatal("env-only flag should have x-quicli-input marker")
+	}
+	if input != "env-only" {
+		t.Errorf("x-quicli-input: got %v, want env-only", input)
+	}
+}
+
+func TestJSONSchemaNonEnvOnlyNoMarker(t *testing.T) {
+	cli := Cli{
+		Flags: Flags{{Name: "count", Default: 0, Description: "count"}},
+	}
+	schema := cli.JSONSchema()
+	props := schema["properties"].(map[string]any)
+	prop := props["count"].(map[string]any)
+	if _, ok := prop["x-quicli-input"]; ok {
+		t.Error("non-env-only flag should not have x-quicli-input")
+	}
+}

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -27,6 +27,7 @@ type Flag struct {
 	EnvVar            string        // env var override (activated in PR2)
 	Required          bool          // flag must be explicitly provided
 	Choices           []string      // valid values (for string flags)
+	EnvOnly           bool          // flag is only settable via environment variable (not registered as CLI flag)
 }
 
 type Flags []Flag
@@ -140,6 +141,9 @@ func (c *Cli) Parse() (config Config) {
 			fmt.Println(QUICLI_ERROR_PREFIX + "empty flag name definition")
 			os.Exit(2)
 		}
+		if f.EnvOnly {
+			continue
+		}
 		if f.Default == nil {
 			f.Default = false
 		}
@@ -185,6 +189,7 @@ func (c *Cli) Parse() (config Config) {
 	fs.Parse(os.Args[1:])
 	config.Args = fs.Args()
 	applyEnvVars(c.Flags, fs)
+	applyEnvOnlyFlags(c.Flags, config)
 
 	if completionShell != "" {
 		script, err := generateCompletion(c, completionShell)

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -184,12 +184,26 @@ func (c *Cli) Parse() (config Config) {
 	var jsonSchemaFlag bool
 	fs.BoolVar(&jsonSchemaFlag, "json-schema", false, "output JSON Schema and exit")
 
+	var debugOptionsFlag bool
+	fs.BoolVar(&debugOptionsFlag, "debug-options", false, "show flag values and their sources")
+
 	wUsage.Flush()
 	fs.Usage = func() { fmt.Print(usage.String()) }
 	fs.Parse(os.Args[1:])
+
+	cliSet := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		cliSet[f.Name] = true
+	})
+
 	config.Args = fs.Args()
 	applyEnvVars(c.Flags, fs)
 	applyEnvOnlyFlags(c.Flags, config)
+
+	if debugOptionsFlag {
+		sources := buildSourceMap(c.Flags, fs, cliSet)
+		printDebugOptions(c.Flags, config, sources)
+	}
 
 	if completionShell != "" {
 		script, err := generateCompletion(c, completionShell)

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -212,6 +212,7 @@ func (c *Cli) Parse() (config Config) {
 	}
 
 	validateFlags(c.Flags, fs)
+	validateEnvOnlyFlags(c.Flags)
 	return config
 }
 

--- a/pkg/quicli/runfunc.go
+++ b/pkg/quicli/runfunc.go
@@ -74,8 +74,16 @@ func flagsFromStruct(t reflect.Type) ([]Flag, error) {
 			Name:        strings.ToLower(field.Name),
 			Description: cliTag,
 			ShortName:   field.Tag.Get("short"),
-			EnvVar:      field.Tag.Get("env"),
 			Required:    field.Tag.Get("required") == "true",
+		}
+		envTag := field.Tag.Get("env")
+		if envTag == "only" {
+			f.EnvOnly = true
+		} else if strings.HasPrefix(envTag, "only:") {
+			f.EnvOnly = true
+			f.EnvVar = strings.TrimPrefix(envTag, "only:")
+		} else {
+			f.EnvVar = envTag
 		}
 		if choicesTag := field.Tag.Get("choices"); choicesTag != "" {
 			f.Choices = strings.Split(choicesTag, ",")

--- a/pkg/quicli/runfunc_test.go
+++ b/pkg/quicli/runfunc_test.go
@@ -286,6 +286,45 @@ func TestFlagsFromStructRequired(t *testing.T) {
 	}
 }
 
+func TestFlagsFromStructEnvOnly(t *testing.T) {
+	type opts struct {
+		Token string `cli:"auth token" env:"only"`
+		Name  string `cli:"your name"`
+	}
+	flags, err := flagsFromStruct(reflect.TypeOf(opts{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flags) != 2 {
+		t.Fatalf("got %d flags, want 2", len(flags))
+	}
+	if !flags[0].EnvOnly {
+		t.Error("Token flag should have EnvOnly=true")
+	}
+	if flags[0].EnvVar != "" {
+		t.Errorf("EnvVar should be empty (auto-derived), got %q", flags[0].EnvVar)
+	}
+	if flags[1].EnvOnly {
+		t.Error("Name flag should not be env-only")
+	}
+}
+
+func TestFlagsFromStructEnvOnlyWithExplicitVar(t *testing.T) {
+	type opts struct {
+		Token string `cli:"auth token" env:"only:MY_TOKEN"`
+	}
+	flags, err := flagsFromStruct(reflect.TypeOf(opts{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !flags[0].EnvOnly {
+		t.Error("should be EnvOnly")
+	}
+	if flags[0].EnvVar != "MY_TOKEN" {
+		t.Errorf("EnvVar: got %q, want MY_TOKEN", flags[0].EnvVar)
+	}
+}
+
 func TestFlagsFromStructChoices(t *testing.T) {
 	type opts struct {
 		Format string `cli:"output format" choices:"json,yaml,csv"`
@@ -377,5 +416,26 @@ func TestNewSubcommandDefaultsUsed(t *testing.T) {
 
 	if gotName != "stranger" {
 		t.Errorf("default: got %q, want stranger", gotName)
+	}
+}
+
+func TestRunFuncEnvOnly(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("PROG_TOKEN", "secret123")
+
+	type Opts struct {
+		Token string `cli:"auth token" env:"only"`
+		Name  string `cli:"your name" default:"world"`
+	}
+	var gotToken, gotName string
+	RunFunc("prog [flags]", "test", func(o Opts) {
+		gotToken = o.Token
+		gotName = o.Name
+	})
+	if gotToken != "secret123" {
+		t.Errorf("RunFunc env-only: got %q, want secret123", gotToken)
+	}
+	if gotName != "world" {
+		t.Errorf("RunFunc name: got %q, want world", gotName)
 	}
 }

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -208,6 +208,9 @@ func (c *Cli) RunWithSubcommand() {
 	var jsonSchemaFlag bool
 	fs.BoolVar(&jsonSchemaFlag, "json-schema", false, "output JSON Schema and exit")
 
+	var debugOptionsFlag bool
+	fs.BoolVar(&debugOptionsFlag, "debug-options", false, "show flag values and their sources")
+
 	wUsage.Flush()
 	// Parse
 	fs.Usage = func() { fmt.Print(usage.String()) }
@@ -216,6 +219,12 @@ func (c *Cli) RunWithSubcommand() {
 	} else if len(os.Args) > 2 {
 		fs.Parse(os.Args[2:])
 	}
+
+	cliSet := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		cliSet[f.Name] = true
+	})
+
 	config.Args = fs.Args()
 	allFlags := c.Flags
 	if !isRootCommand(c.Subcommands) {
@@ -224,6 +233,11 @@ func (c *Cli) RunWithSubcommand() {
 	}
 	applyEnvVars(allFlags, fs)
 	applyEnvOnlyFlags(allFlags, config)
+
+	if debugOptionsFlag {
+		sources := buildSourceMap(allFlags, fs, cliSet)
+		printDebugOptions(allFlags, config, sources)
+	}
 
 	if completionShell != "" {
 		script, err := generateCompletion(c, completionShell)

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -255,6 +255,7 @@ func (c *Cli) RunWithSubcommand() {
 	}
 
 	validateFlags(allFlags, fs)
+	validateEnvOnlyFlags(allFlags)
 
 	// Run
 	if isRootCommand(c.Subcommands) {

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -80,6 +80,9 @@ func (c *Cli) RunWithSubcommand() {
 
 	//flags
 	for _, f := range c.Flags {
+		if f.EnvOnly {
+			continue
+		}
 		// prepation checks
 		if len(f.Name) == 0 {
 			fmt.Println(QUICLI_ERROR_PREFIX + "empty flag name defintion")
@@ -220,6 +223,7 @@ func (c *Cli) RunWithSubcommand() {
 		allFlags = append(allFlags, sub.Flags...)
 	}
 	applyEnvVars(allFlags, fs)
+	applyEnvOnlyFlags(allFlags, config)
 
 	if completionShell != "" {
 		script, err := generateCompletion(c, completionShell)

--- a/pkg/quicli/validate.go
+++ b/pkg/quicli/validate.go
@@ -53,6 +53,35 @@ func validateFlags(flags []Flag, fs *flag.FlagSet) {
 	}
 }
 
+// checkEnvOnlyFlags validates env-only flags.
+// Currently checks: required env-only flags must have their env var set.
+func checkEnvOnlyFlags(flags []Flag) []string {
+	var errs []string
+	for _, f := range flags {
+		if !f.EnvOnly || !f.Required {
+			continue
+		}
+		envKey := f.EnvVar
+		if envKey == "" {
+			envKey = envVarName(os.Args[0], f.Name)
+		}
+		if _, ok := os.LookupEnv(envKey); !ok {
+			errs = append(errs, fmt.Sprintf("required env-only flag --%s is missing (set %s)", f.Name, envKey))
+		}
+	}
+	return errs
+}
+
+// validateEnvOnlyFlags prints env-only validation errors and exits if any found.
+func validateEnvOnlyFlags(flags []Flag) {
+	if errs := checkEnvOnlyFlags(flags); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, QUICLI_ERROR_PREFIX+e)
+		}
+		os.Exit(2)
+	}
+}
+
 // flagWasSet returns true if the flag was explicitly set via CLI or env var.
 func flagWasSet(f Flag, set map[string]bool) bool {
 	if set[f.Name] {

--- a/pkg/quicli/validate_test.go
+++ b/pkg/quicli/validate_test.go
@@ -423,3 +423,25 @@ func TestEnvOnlyInSubcommand(t *testing.T) {
 		t.Errorf("token: got %q, want abc123", gotToken)
 	}
 }
+
+func TestCheckEnvOnlyRequiredMissing(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	flags := []Flag{{Name: "token", Default: "", Description: "token", EnvOnly: true, Required: true}}
+	errs := checkEnvOnlyFlags(flags)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0], "token") {
+		t.Errorf("error should mention token: %s", errs[0])
+	}
+}
+
+func TestCheckEnvOnlyRequiredProvided(t *testing.T) {
+	defer setArgs([]string{"prog"})()
+	t.Setenv("PROG_TOKEN", "abc")
+	flags := []Flag{{Name: "token", Default: "", Description: "token", EnvOnly: true, Required: true}}
+	errs := checkEnvOnlyFlags(flags)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}

--- a/pkg/quicli/validate_test.go
+++ b/pkg/quicli/validate_test.go
@@ -393,3 +393,33 @@ func TestFlagWasSetNotSet(t *testing.T) {
 		t.Error("flagWasSet should return false when nothing is set")
 	}
 }
+
+func TestEnvOnlyInSubcommand(t *testing.T) {
+	defer setArgs([]string{"prog", "deploy", "--target", "prod"})()
+	t.Setenv("PROG_TOKEN", "abc123")
+
+	var gotTarget, gotToken string
+	cli := Cli{
+		Usage:       "prog [command]",
+		Description: "test",
+		Flags: Flags{
+			{Name: "token", Default: "", Description: "auth token", EnvOnly: true,
+				SharedSubcommand: SubcommandSet{"deploy"}},
+		},
+		Function: func(cfg Config) {},
+		Subcommands: Subcommands{
+			{Name: "deploy", Description: "deploy", Function: func(cfg Config) {
+				gotTarget = cfg.GetStringFlag("target")
+				gotToken = cfg.GetStringFlag("token")
+			}, Flags: Flags{{Name: "target", Default: "", Description: "deploy target", Required: true}}},
+		},
+	}
+	cli.RunWithSubcommand()
+
+	if gotTarget != "prod" {
+		t.Errorf("target: got %q, want prod", gotTarget)
+	}
+	if gotToken != "abc123" {
+		t.Errorf("token: got %q, want abc123", gotToken)
+	}
+}


### PR DESCRIPTION
## Summary

- **Env-only flags**: flags settable exclusively via environment variables (`EnvOnly: true` / `env:"only"` struct tag). Hidden from `--help` and shell completion, visible in `--json-schema` with `x-quicli-input: "env-only"`. Ideal for secrets.
- **Debug options**: `--debug-options` flag prints a table showing each flag's value and source (`cli`, `env (VAR)`, `default`). Env-only values masked as `***`.
- **MCP bridge**: standalone `cmd/quicli-mcp` binary that turns any quicli app into an MCP tool server via `--json-schema`. Pure stdlib, zero changes to quicli core.
- **AI agent integration docs**: README section covering MCP setup, direct API usage, env-only secrets, and debug-options.

## Test plan

- [ ] 120 quicli library tests pass (including 25 new tests for env-only, debug-options)
- [ ] 30 MCP bridge tests pass (schema parsing, args translation, JSON-RPC handlers, edge cases)
- [ ] `go vet` clean on both modules
- [ ] `quicli-mcp` binary builds and starts correctly
- [ ] Verify `--debug-options` output with mixed CLI/env/default flags
- [ ] Verify env-only flags hidden from `--help` and completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)