### PR TITLE
examples: add validation, envvar, duration, and custom flag.Value

### DIFF
--- a/examples/custom_flag_value.go
+++ b/examples/custom_flag_value.go
@@ -1,0 +1,54 @@
+//go:build ignore
+
+// custom_flag_value — demonstrates using a custom type that implements
+// flag.Value for structured parsing. Any type whose pointer receiver
+// implements Set(string) error and String() string works out of the box.
+//
+// Try:
+//   go run examples/custom_flag_value.go --help
+//   go run examples/custom_flag_value.go --listen 0.0.0.0:9090
+//   go run examples/custom_flag_value.go --listen :3000 --prefix /api
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+// Addr is a custom flag type for host:port pairs.
+type Addr struct {
+	Host string
+	Port string
+}
+
+func (a *Addr) String() string {
+	if a.Host == "" && a.Port == "" {
+		return ""
+	}
+	return a.Host + ":" + a.Port
+}
+
+func (a *Addr) Set(s string) error {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected host:port, got %q", s)
+	}
+	a.Host = parts[0]
+	a.Port = parts[1]
+	return nil
+}
+
+type ServeOpts struct {
+	Listen Addr   `cli:"address to listen on" default:"localhost:8080"`
+	Prefix string `cli:"URL path prefix"      default:"/"`
+}
+
+func main() {
+	q.RunFunc("serve [flags]", "Start an HTTP server", func(o ServeOpts) {
+		fmt.Printf("listening on %s\n", o.Listen.String())
+		fmt.Printf("prefix: %s\n", o.Prefix)
+	})
+}

--- a/examples/duration.go
+++ b/examples/duration.go
@@ -1,0 +1,48 @@
+//go:build ignore
+
+// duration — demonstrates time.Duration flag support.
+// Duration flags accept Go duration strings like "5s", "2m30s", "1h".
+//
+// Try:
+//   go run examples/duration.go --help
+//   go run examples/duration.go --timeout 5s --interval 500ms
+//   go run examples/duration.go --timeout 2m --retries 5
+//   go run examples/duration.go                                 # uses defaults
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+type PollOpts struct {
+	URL      string        `cli:"endpoint to poll"             default:"http://localhost:8080/health"`
+	Timeout  time.Duration `cli:"max time to wait"             default:"30s"`
+	Interval time.Duration `cli:"time between attempts"        default:"2s"`
+	Retries  int           `cli:"max number of retries"        default:"10"`
+}
+
+func main() {
+	q.RunFunc("poll [flags]", "Poll an endpoint until healthy", func(o PollOpts) {
+		fmt.Printf("polling %s\n", o.URL)
+		fmt.Printf("  timeout:  %s\n", o.Timeout)
+		fmt.Printf("  interval: %s\n", o.Interval)
+		fmt.Printf("  retries:  %d\n", o.Retries)
+
+		deadline := time.Now().Add(o.Timeout)
+		for i := 1; i <= o.Retries; i++ {
+			if time.Now().After(deadline) {
+				fmt.Println("timed out")
+				return
+			}
+			fmt.Printf("  attempt %d/%d... ok\n", i, o.Retries)
+			if i < o.Retries {
+				time.Sleep(o.Interval)
+			}
+		}
+		fmt.Println("healthy")
+	})
+}

--- a/examples/envvar.go
+++ b/examples/envvar.go
@@ -1,0 +1,42 @@
+//go:build ignore
+
+// envvar — demonstrates environment variable features:
+//   - automatic env var fallback (PROGNAME_FLAGNAME)
+//   - custom env var name via env:"MY_VAR" tag
+//   - env-only flags for secrets (never shown in help or accepted on CLI)
+//   - opting out of env var with env:"-"
+//
+// Try:
+//   go run examples/envvar.go --help
+//   go run examples/envvar.go --host localhost --port 5432
+//   DB_HOST=prod-db go run examples/envvar.go --port 5432
+//   DB_HOST=prod-db DB_TOKEN=secret123 go run examples/envvar.go
+//   go run examples/envvar.go --host localhost --debug-options
+
+package main
+
+import (
+	"fmt"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+type ConnectOpts struct {
+	Host  string `cli:"database host"          default:"localhost" env:"DB_HOST"`
+	Port  int    `cli:"database port"          default:"5432"      env:"DB_PORT"`
+	Token string `cli:"auth token (env only)"  default:""          env:"only:DB_TOKEN"`
+	Query string `cli:"SQL query to run"       default:"SELECT 1"  env:"-"`
+}
+
+func main() {
+	q.RunFunc("dbping [flags]", "Connect to a database and run a query", func(o ConnectOpts) {
+		masked := "***"
+		if o.Token == "" {
+			masked = "(none)"
+		}
+		fmt.Printf("host:  %s\n", o.Host)
+		fmt.Printf("port:  %d\n", o.Port)
+		fmt.Printf("token: %s\n", masked)
+		fmt.Printf("query: %s\n", o.Query)
+	})
+}

--- a/examples/validation.go
+++ b/examples/validation.go
@@ -1,0 +1,38 @@
+//go:build ignore
+
+// validation — demonstrates required flags and choices constraints.
+// quicli validates after all sources (CLI, env vars) have been applied
+// and prints clear error messages on failure.
+//
+// Try:
+//   go run examples/validation.go --help
+//   go run examples/validation.go --name Alice --env prod
+//   go run examples/validation.go --env prod                    # error: --name is required
+//   go run examples/validation.go --name Alice --env staging    # error: invalid choice
+//   go run examples/validation.go --name Alice                  # uses default env "dev"
+
+package main
+
+import (
+	"fmt"
+
+	q "github.com/ariary/quicli/pkg/quicli"
+)
+
+type DeployOpts struct {
+	Name    string `cli:"service name to deploy"         required:"true"`
+	Env     string `cli:"target environment"             default:"dev"  choices:"dev,prod"`
+	Replicas int   `cli:"number of replicas"             default:"1"`
+	DryRun  bool   `cli:"simulate without applying"`
+}
+
+func main() {
+	q.RunFunc("deploy [flags]", "Deploy a service to an environment", func(o DeployOpts) {
+		if o.DryRun {
+			fmt.Printf("[dry-run] would deploy %s to %s with %d replica(s)\n", o.Name, o.Env, o.Replicas)
+			return
+		}
+		fmt.Printf("deploying %s to %s with %d replica(s)...\n", o.Name, o.Env, o.Replicas)
+		fmt.Println("done")
+	})
+}


### PR DESCRIPTION
## Summary
- **validation.go** — `required:"true"` and `choices` constraint tags
- **envvar.go** — custom env var names (`env:"DB_HOST"`), env-only secrets (`env:"only:DB_TOKEN"`), opt-out (`env:"-"`)
- **duration.go** — `time.Duration` flags (`5s`, `2m30s`, `500ms`)
- **custom_flag_value.go** — any type implementing `flag.Value` (demonstrated with a `host:port` parser)

These cover features that had no dedicated example.

## Test plan
- [x] Each example compiles: `go run examples/<file>.go --help`
- [x] Happy paths verified (correct output)
- [x] Error paths verified (required missing → error, invalid choice → error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)