### PR TITLE
fix: make help messages contextual and non-circular

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,19 +162,23 @@ $ mytool --help
 A tool that does things
 
 Usage: mytool [command] [flags]
-Available commands: get, g, list, ls, delete
+Available commands: get (g), list (ls), delete
 
 --verbose  -v   verbose output. (default: false) [env: MYTOOL_VERBOSE]
 
-Use "mytool --help" for more information about the command.
+Use "mytool <command> --help" for more information about a command.
 
 $ mytool get --help
 
+A tool that does things
+
+Usage: mytool [command] [flags]
 Command get: get a resource
 
 --id      -i   resource id. (default: "") [env: MYTOOL_ID]
 --output  -o   output format. (default: "text") [env: MYTOOL_OUTPUT]
---verbose -v   verbose output. (default: false) [env: MYTOOL_VERBOSE]
+
+Use "mytool --help" for more information about available commands.
 ```
 
 ```bash

--- a/pkg/quicli/quicli.go
+++ b/pkg/quicli/quicli.go
@@ -169,7 +169,7 @@ func (c *Cli) Parse() (config Config) {
 			}
 		}
 	}
-	fmt.Fprintf(wUsage, "\nUse \""+color.Yellow(os.Args[0])+" --help\" for more information about the command.\n")
+	// no footer hint here — this IS the help output; a circular "--help" hint adds noise
 
 	var cheatSheet bool
 	if len(c.CheatSheet) > 0 {

--- a/pkg/quicli/subcommand.go
+++ b/pkg/quicli/subcommand.go
@@ -50,12 +50,7 @@ func (c *Cli) RunWithSubcommand() {
 	//Description
 	if isRootCommand(c.Subcommands) {
 		if len(c.Subcommands) > 0 {
-			subcommandSet := []string{}
-			for _, sub := range c.Subcommands {
-				subcommandSet = append(subcommandSet, sub.Name)
-				subcommandSet = append(subcommandSet, sub.Aliases...)
-			}
-			fmt.Fprintf(wUsage, color.Yellow(c.Description)+"\n\nUsage: "+c.Usage+"\nAvailable commands: "+strings.Join(subcommandSet, ", ")+"\n\n")
+			fmt.Fprintf(wUsage, color.Yellow(c.Description)+"\n\nUsage: "+c.Usage+"\nAvailable commands: "+formatSubcommandList(c.Subcommands)+"\n\n")
 		} else {
 			fmt.Fprintf(wUsage, color.Yellow(c.Description)+"\n\nUsage: "+c.Usage+"\n\n")
 		}
@@ -192,7 +187,11 @@ func (c *Cli) RunWithSubcommand() {
 		}
 	}
 
-	fmt.Fprintf(wUsage, "\nUse \""+color.Yellow(os.Args[0])+" --help\" for more information about the command.\n")
+	if isRootCommand(c.Subcommands) && len(c.Subcommands) > 0 {
+		fmt.Fprintf(wUsage, "\nUse \""+color.Yellow(os.Args[0])+" <command> --help\" for more information about a command.\n")
+	} else if !isRootCommand(c.Subcommands) {
+		fmt.Fprintf(wUsage, "\nUse \""+color.Yellow(os.Args[0])+" --help\" for more information about available commands.\n")
+	}
 
 	//cheat sheet pt1
 	var cheatSheet bool
@@ -275,12 +274,7 @@ func (c *Cli) RunWithSubcommand() {
 	if isRootCommand(c.Subcommands) {
 		if c.Function == nil {
 			if len(os.Args) > 1 && !strings.HasPrefix(os.Args[1], "-") {
-				subcommandSet := []string{}
-				for _, sub := range c.Subcommands {
-					subcommandSet = append(subcommandSet, sub.Name)
-					subcommandSet = append(subcommandSet, sub.Aliases...)
-				}
-				fmt.Println(QUICLI_ERROR_PREFIX + "unknown subcommand '" + os.Args[1] + "'. Available commands: " + strings.Join(subcommandSet, ", "))
+				fmt.Println(QUICLI_ERROR_PREFIX + "unknown subcommand '" + os.Args[1] + "'. Available commands: " + formatSubcommandList(c.Subcommands))
 				os.Exit(2)
 			}
 			fs.Usage()
@@ -352,6 +346,20 @@ func checkSubcommandFunctionIsDefined(c *Cli) {
 			os.Exit(2)
 		}
 	}
+}
+
+// formatSubcommandList: return a comma-separated list of subcommand names with aliases in parentheses
+// e.g. "serve (s), build (b), list (ls, l)"
+func formatSubcommandList(subcommands Subcommands) string {
+	entries := make([]string, 0, len(subcommands))
+	for _, sub := range subcommands {
+		entry := sub.Name
+		if len(sub.Aliases) > 0 {
+			entry += " (" + strings.Join(sub.Aliases, ", ") + ")"
+		}
+		entries = append(entries, entry)
+	}
+	return strings.Join(entries, ", ")
 }
 
 // checkSubcommandAliasesUniqueness: assert the subcommand Aliases are unique (ie not same alias for two different subcommands), exit otherwise


### PR DESCRIPTION
## Summary
- Remove the circular `Use "prog --help"` hint that was shown *inside* the help output itself
- Root command with subcommands now shows `Use "prog <command> --help" for more information about a command.`
- Subcommand help now shows `Use "prog --help" for more information about available commands.`
- Root command without subcommands: no footer hint (clean, no noise)
- Update README examples to match actual output (alias format, removed stale flags)

## Test plan
- [x] `go test ./pkg/...` passes
- [x] Built and ran `sayhello_subcommand` example — verified all three help cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)